### PR TITLE
feat: Implement auto-focus on step changes in New Case form

### DIFF
--- a/src/pages/CaseNew.tsx
+++ b/src/pages/CaseNew.tsx
@@ -191,6 +191,23 @@ const CaseNew = () => {
     mode: "onChange", // Enable real-time validation
   });
 
+  // Auto-focus on tab change
+  useEffect(() => {
+    // Adding a timeout to ensure the field is rendered before focusing
+    const timer = setTimeout(() => {
+      if (activeTab === "case-info") {
+        form.setFocus("chiefComplaintAnalysis");
+      } else if (activeTab === "patient-info") {
+        form.setFocus("patientName");
+      } else if (activeTab === "clinical-details") {
+        form.setFocus("history");
+      } else if (activeTab === "learning") {
+        form.setFocus("learningPoints");
+      }
+    }, 100); // 100ms delay, adjust if needed
+    return () => clearTimeout(timer);
+  }, [activeTab, form]);
+
   // Memoized form steps for progress indicator
   const formSteps = useMemo(() =>
     TAB_CONFIG.map(({ id, label }) => ({


### PR DESCRIPTION
This commit introduces auto-focus functionality to the multi-step form in `src/pages/CaseNew.tsx`.

When you navigate between steps, focus is programmatically moved to the first meaningful element in the new step. This improves efficiency for keyboard users and provides a clear signal to assistive technologies that the content has changed.

The `useEffect` hook and `form.setFocus()` from `react-hook-form` are used to achieve this. A 100ms delay is added before setting focus to ensure the element is rendered.

The following fields are focused on their respective tabs:
- Case Info: `chiefComplaintAnalysis`
- Patient: `patientName`
- Clinical: `history`
- Learning: `learningPoints`

This addresses the issue of improving keyboard navigation and accessibility in multi-step forms.