### PR TITLE
feat: Implement new dashboard and refactor case creation flow

### DIFF
--- a/src/components/cases/create/CaseInfoStep.tsx
+++ b/src/components/cases/create/CaseInfoStep.tsx
@@ -1,0 +1,128 @@
+import { Control } from "react-hook-form";
+import { z } from "zod";
+import {
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+// 1. Zod Schema Definition
+export const caseInfoSchema = z.object({
+  caseTitle: z.string().min(3, "Title must be at least 3 characters long."),
+  chiefComplaint: z.string().min(5, "Chief complaint must be at least 5 characters long."),
+  specialty: z.string().min(1, "Specialty is required."),
+});
+
+// Optional: Define a type for the form data based on the schema
+export type CaseInfoFormData = z.infer<typeof caseInfoSchema>;
+
+// 2. Component Props
+interface CaseInfoStepProps {
+  control: Control<any>; // Control object from react-hook-form
+  // We can add other RHF methods if needed, like formState, trigger, etc.
+  // For now, 'control' is sufficient as per the subtask description.
+}
+
+const specialties = [
+  "Cardiology",
+  "Neurology",
+  "Pediatrics",
+  "Orthopedics",
+  "General Medicine",
+  "Oncology",
+  "Dermatology",
+  "Endocrinology",
+  "Gastroenterology",
+  "Pulmonology",
+];
+
+// 3. Component Definition
+export const CaseInfoStep: React.FC<CaseInfoStepProps> = ({ control }) => {
+  return (
+    <div className="space-y-6 py-2">
+      {/* Case Title Field */}
+      <FormField
+        control={control}
+        name="caseTitle"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Case Title</FormLabel>
+            <FormControl>
+              <Input placeholder="e.g., Acute Myocardial Infarction" {...field} />
+            </FormControl>
+            <FormDescription>
+              A concise and descriptive title for the case.
+            </FormDescription>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      {/* Chief Complaint Field */}
+      <FormField
+        control={control}
+        name="chiefComplaint"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Chief Complaint</FormLabel>
+            <FormControl>
+              <Textarea
+                placeholder="e.g., Patient presents with severe chest pain for 2 hours..."
+                className="min-h-[100px]"
+                {...field}
+              />
+            </FormControl>
+            <FormDescription>
+              The primary reason the patient sought medical attention, in their own words if possible.
+            </FormDescription>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      {/* Specialty Field */}
+      <FormField
+        control={control}
+        name="specialty"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Medical Specialty</FormLabel>
+            <Select onValueChange={field.onChange} defaultValue={field.value}>
+              <FormControl>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select a medical specialty" />
+                </SelectTrigger>
+              </FormControl>
+              <SelectContent>
+                {specialties.map((specialty) => (
+                  <SelectItem key={specialty} value={specialty}>
+                    {specialty}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <FormDescription>
+              The primary medical specialty relevant to this case.
+            </FormDescription>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </div>
+  );
+};
+
+// 4. Export the component and schema
+export default CaseInfoStep;

--- a/src/components/cases/create/ClinicalDetailStep.tsx
+++ b/src/components/cases/create/ClinicalDetailStep.tsx
@@ -1,0 +1,194 @@
+import { Control, UseFormSetValue, UseFormWatch } from "react-hook-form";
+import { z } from "zod";
+import {
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+} from "@/components/ui/form";
+import { Textarea } from "@/components/ui/textarea";
+import { InteractiveBodyDiagram } from "@/components/body-diagram/InteractiveBodyDiagram";
+import { SymptomChecklist } from "@/components/symptoms/SymptomChecklist";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+// 1. Zod Schema Definition
+export const clinicalDetailStepSchema = z.object({
+  selectedBodyParts: z.array(z.string()).optional().default([]),
+  symptoms: z.array(z.string()).optional().default([]),
+  relatedSystemsNotes: z.string().optional(),
+  vitalsNotes: z.string().optional(),
+  labResultsNotes: z.string().optional(),
+  radiologyNotes: z.string().optional(),
+});
+
+// Optional: Define a type for the form data based on the schema
+export type ClinicalDetailFormData = z.infer<typeof clinicalDetailStepSchema>;
+
+// 2. Component Props
+interface ClinicalDetailStepProps {
+  control: Control<any>;
+  setValue: UseFormSetValue<any>;
+  watch: UseFormWatch<any>;
+}
+
+// 3. Component Definition
+export const ClinicalDetailStep: React.FC<ClinicalDetailStepProps> = ({ control, setValue, watch }) => {
+  const currentSelectedBodyParts = watch("selectedBodyParts", []);
+
+  const handleBodyPartSelected = (part: string) => {
+    const updatedSelectedParts = currentSelectedBodyParts.includes(part)
+      ? currentSelectedBodyParts.filter((p: string) => p !== part)
+      : [...currentSelectedBodyParts, part];
+    setValue("selectedBodyParts", updatedSelectedParts, { shouldValidate: true });
+  };
+
+  const handleSymptomsSelected = (symptoms: string[]) => {
+    setValue("symptoms", symptoms, { shouldValidate: true });
+  };
+
+  return (
+    <div className="space-y-6 py-2">
+      <div className="grid md:grid-cols-2 gap-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Affected Body Parts</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <InteractiveBodyDiagram
+              onBodyPartSelected={handleBodyPartSelected}
+              highlightedSystems={currentSelectedBodyParts} // Use current selection to highlight
+            />
+            <FormDescription className="mt-2">
+              Click on body parts to select/deselect. Selected: {currentSelectedBodyParts.join(", ") || "None"}
+            </FormDescription>
+             {/* Hidden FormField to register 'selectedBodyParts' with RHF and show validation errors */}
+            <FormField
+              control={control}
+              name="selectedBodyParts"
+              render={() => (
+                <FormItem>
+                  <FormMessage className="mt-2" />
+                </FormItem>
+              )}
+            />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Reported Symptoms</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <SymptomChecklist onSymptomsSelected={handleSymptomsSelected} />
+             {/* Hidden FormField to register 'symptoms' with RHF and show validation errors */}
+             <FormField
+              control={control}
+              name="symptoms"
+              render={() => (
+                <FormItem>
+                  <FormMessage className="mt-2" />
+                </FormItem>
+              )}
+            />
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Clinical Notes</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <FormField
+            control={control}
+            name="relatedSystemsNotes"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Related Systems & Initial Observations</FormLabel>
+                <FormControl>
+                  <Textarea
+                    placeholder="Describe any related physiological systems, initial observations, or differential diagnoses considerations based on body parts and symptoms..."
+                    className="min-h-[100px]"
+                    {...field}
+                  />
+                </FormControl>
+                <FormDescription>
+                  Note down observations about systems potentially involved (e.g., Cardiovascular, Respiratory).
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={control}
+            name="vitalsNotes"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Vitals & Physical Examination Notes</FormLabel>
+                <FormControl>
+                  <Textarea
+                    placeholder="Record key vital signs (e.g., BP, HR, Temp, RR, SpO2) and physical examination findings..."
+                    className="min-h-[100px]"
+                    {...field}
+                  />
+                </FormControl>
+                <FormDescription>
+                  Include any relevant measurements and observations from the physical exam.
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={control}
+            name="labResultsNotes"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Laboratory Results Notes</FormLabel>
+                <FormControl>
+                  <Textarea
+                    placeholder="Summarize significant lab findings (e.g., CBC, BMP, specific markers)..."
+                    className="min-h-[100px]"
+                    {...field}
+                  />
+                </FormControl>
+                <FormDescription>
+                  Note abnormal values or results that influence the case.
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={control}
+            name="radiologyNotes"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Radiology & Imaging Notes</FormLabel>
+                <FormControl>
+                  <Textarea
+                    placeholder="Describe findings from X-rays, CT scans, MRIs, ultrasounds, etc..."
+                    className="min-h-[100px]"
+                    {...field}
+                  />
+                </FormControl>
+                <FormDescription>
+                  Summarize key imaging results and their interpretations.
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+// 4. Export the component and schema
+export default ClinicalDetailStep;

--- a/src/components/cases/create/LearningPointsStep.tsx
+++ b/src/components/cases/create/LearningPointsStep.tsx
@@ -1,0 +1,173 @@
+import { Control, useFieldArray } from "react-hook-form";
+import { z } from "zod";
+import {
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Trash2, PlusCircle } from "lucide-react";
+
+// 1. Zod Schema Definition
+export const learningPointsStepSchema = z.object({
+  learningPoints: z.string().optional(),
+  generalNotes: z.string().optional(),
+  resourceLinks: z
+    .array(
+      z.object({
+        url: z.string().url("Invalid URL format.").min(1, "URL cannot be empty."),
+        description: z.string().optional(),
+      })
+    )
+    .optional().default([]),
+});
+
+// Optional: Define a type for the form data based on the schema
+export type LearningPointsFormData = z.infer<typeof learningPointsStepSchema>;
+
+// 2. Component Props
+interface LearningPointsStepProps {
+  control: Control<any>; // Control object from react-hook-form
+}
+
+// 3. Component Definition
+export const LearningPointsStep: React.FC<LearningPointsStepProps> = ({ control }) => {
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: "resourceLinks",
+  });
+
+  return (
+    <div className="space-y-6 py-2">
+      <Card>
+        <CardHeader>
+          <CardTitle>Educational Takeaways</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <FormField
+            control={control}
+            name="learningPoints"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Key Learning Points</FormLabel>
+                <FormControl>
+                  <Textarea
+                    placeholder="e.g., - Importance of early ECG in suspected MI.&#10;- Differential diagnosis for acute chest pain.&#10;- Management protocol for STEMI."
+                    className="min-h-[120px]"
+                    {...field}
+                  />
+                </FormControl>
+                <FormDescription>
+                  Summarize the main educational insights or lessons learned from this case. Use bullet points for clarity.
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={control}
+            name="generalNotes"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>General Reflections & Notes</FormLabel>
+                <FormControl>
+                  <Textarea
+                    placeholder="Any other thoughts, reflections, areas for further study, or personal notes related to this case..."
+                    className="min-h-[100px]"
+                    {...field}
+                  />
+                </FormControl>
+                <FormDescription>
+                  Optional space for additional reflections or miscellaneous notes.
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Supporting Resources</CardTitle>
+          <FormDescription>
+            Add links to relevant articles, guidelines, studies, or other educational materials.
+          </FormDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {fields.map((item, index) => (
+            <Card key={item.id} className="p-4 bg-muted/30 shadow-sm">
+              <div className="flex flex-col md:flex-row gap-4">
+                <FormField
+                  control={control}
+                  name={`resourceLinks.${index}.url`}
+                  render={({ field }) => (
+                    <FormItem className="flex-1">
+                      <FormLabel>URL</FormLabel>
+                      <FormControl>
+                        <Input placeholder="https://example.com/article" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={control}
+                  name={`resourceLinks.${index}.description`}
+                  render={({ field }) => (
+                    <FormItem className="flex-1">
+                      <FormLabel>Description (Optional)</FormLabel>
+                      <FormControl>
+                        <Input placeholder="e.g., AHA Guidelines for STEMI" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <div className="pt-1 md:pt-6">
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    size="icon"
+                    onClick={() => remove(index)}
+                    aria-label="Remove resource link"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+            </Card>
+          ))}
+           {/* FormField to show array-level errors for resourceLinks if any */}
+           <FormField
+            control={control}
+            name="resourceLinks"
+            render={() => (
+              <FormItem>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => append({ url: "", description: "" })}
+            className="mt-2"
+          >
+            <PlusCircle className="mr-2 h-4 w-4" /> Add Resource Link
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+// 4. Export the component and schema
+export default LearningPointsStep;

--- a/src/components/cases/create/PatientStep.tsx
+++ b/src/components/cases/create/PatientStep.tsx
@@ -1,0 +1,126 @@
+import { Control } from "react-hook-form";
+import { z } from "zod";
+import {
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+// 1. Zod Schema Definition
+export const patientStepSchema = z.object({
+  patientAge: z.coerce
+    .number({ invalid_type_error: "Age must be a number." })
+    .int("Age must be an integer.")
+    .positive("Age must be a positive number.")
+    .optional()
+    .or(z.literal("")), // Allow empty string, which will be coerced to undefined by optional()
+  patientSex: z.enum(["Male", "Female", "Other", "Prefer not to say"]).optional(),
+  medicalHistory: z.string().optional(),
+});
+
+// Optional: Define a type for the form data based on the schema
+export type PatientStepFormData = z.infer<typeof patientStepSchema>;
+
+// 2. Component Props
+interface PatientStepProps {
+  control: Control<any>; // Control object from react-hook-form
+}
+
+const sexOptions = ["Male", "Female", "Other", "Prefer not to say"];
+
+// 3. Component Definition
+export const PatientStep: React.FC<PatientStepProps> = ({ control }) => {
+  return (
+    <div className="space-y-6 py-2">
+      {/* Patient Age Field */}
+      <FormField
+        control={control}
+        name="patientAge"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Patient Age (Optional)</FormLabel>
+            <FormControl>
+              <Input 
+                type="number" 
+                placeholder="e.g., 35" 
+                {...field} 
+                onChange={e => field.onChange(e.target.value === '' ? '' : Number(e.target.value))}
+                value={field.value === undefined || field.value === null ? '' : String(field.value)}
+              />
+            </FormControl>
+            <FormDescription>
+              The patient's age in years.
+            </FormDescription>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      {/* Patient Sex Field */}
+      <FormField
+        control={control}
+        name="patientSex"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Patient Sex (Optional)</FormLabel>
+            <Select onValueChange={field.onChange} defaultValue={field.value}>
+              <FormControl>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select patient's sex" />
+                </SelectTrigger>
+              </FormControl>
+              <SelectContent>
+                {sexOptions.map((option) => (
+                  <SelectItem key={option} value={option}>
+                    {option}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <FormDescription>
+              The patient's biological sex or gender identity.
+            </FormDescription>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      {/* Relevant Medical History Field */}
+      <FormField
+        control={control}
+        name="medicalHistory"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Relevant Medical History (Optional)</FormLabel>
+            <FormControl>
+              <Textarea
+                placeholder="e.g., Hypertension, Type 2 Diabetes, Previous MI..."
+                className="min-h-[100px]"
+                {...field}
+              />
+            </FormControl>
+            <FormDescription>
+              A brief summary of the patient's relevant past medical conditions or surgeries.
+            </FormDescription>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </div>
+  );
+};
+
+// 4. Export the component and schema
+export default PatientStep;

--- a/src/components/dashboard/ActiveCasesWidget.tsx
+++ b/src/components/dashboard/ActiveCasesWidget.tsx
@@ -1,0 +1,13 @@
+import { StatCard } from "@/components/shared/StatCard";
+import { Briefcase } from "lucide-react";
+
+export function ActiveCasesWidget() {
+  return (
+    <StatCard
+      title="Active Cases"
+      value="0" 
+      icon={<Briefcase className="h-4 w-4 text-muted-foreground" />}
+      description="Currently ongoing cases"
+    />
+  );
+}

--- a/src/components/dashboard/CompletedWidget.tsx
+++ b/src/components/dashboard/CompletedWidget.tsx
@@ -1,0 +1,13 @@
+import { StatCard } from "@/components/shared/StatCard";
+import { CheckCircle } from "lucide-react";
+
+export function CompletedWidget() {
+  return (
+    <StatCard
+      title="Completed Cases"
+      value="0" 
+      icon={<CheckCircle className="h-4 w-4 text-muted-foreground" />}
+      description="Successfully closed cases"
+    />
+  );
+}

--- a/src/components/dashboard/DraftsWidget.tsx
+++ b/src/components/dashboard/DraftsWidget.tsx
@@ -1,0 +1,13 @@
+import { StatCard } from "@/components/shared/StatCard";
+import { FileEdit } from "lucide-react";
+
+export function DraftsWidget() {
+  return (
+    <StatCard
+      title="Drafts"
+      value="0" 
+      icon={<FileEdit className="h-4 w-4 text-muted-foreground" />}
+      description="Cases saved as drafts"
+    />
+  );
+}

--- a/src/components/dashboard/QuickStartPanel.tsx
+++ b/src/components/dashboard/QuickStartPanel.tsx
@@ -1,0 +1,59 @@
+import { Link } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress"; // Added for potential draft progress
+
+export function QuickStartPanel() {
+  // Placeholder for actual draft cases
+  const draftCases = [
+    { id: 1, title: "Draft: Follow-up on Patient Y", progress: 50, currentStep: "Step 2 of 4: Patient Info" },
+    { id: 2, title: "Draft: Initial Assessment for Patient Z", progress: 25, currentStep: "Step 1 of 4: Chief Complaint" },
+  ];
+  // const draftCases = []; // Use this to test the "No draft cases" message
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Quick Start</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <Link to="/cases/new" className="block">
+          <Button size="lg" className="w-full text-lg py-6 shadow-md hover:shadow-lg transition-shadow">
+            + New Clinical Case
+          </Button>
+        </Link>
+
+        <div>
+          <h3 className="text-md font-semibold mb-3 text-foreground">Resume Drafts</h3>
+          {draftCases.length > 0 ? (
+            <div className="space-y-4">
+              {draftCases.map((draft) => (
+                <Link to={`/cases/new?draftId=${draft.id}`} key={draft.id} className="block hover:no-underline">
+                  <Card className="hover:shadow-md transition-shadow bg-background/50 hover:bg-background/80">
+                    <CardContent className="p-4">
+                      <div className="flex justify-between items-center mb-2">
+                        <p className="text-sm font-medium text-foreground">{draft.title}</p>
+                        {/* Optional: Add an icon or action here, e.g., a resume button or delete icon */}
+                      </div>
+                      <Progress value={draft.progress} className="h-2 mb-1" />
+                      <p className="text-xs text-muted-foreground">{draft.currentStep}</p>
+                    </CardContent>
+                  </Card>
+                </Link>
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground text-center py-4">
+              No draft cases to resume. Start a new case to see it here.
+            </p>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/RecentActivity.tsx
+++ b/src/components/dashboard/RecentActivity.tsx
@@ -1,0 +1,47 @@
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export function RecentActivity() {
+  // Placeholder for actual activity items
+  const activityItems = [
+    { id: 1, description: "Case 'Viral Pneumonia' updated", time: "2 hours ago" },
+    { id: 2, description: "New case 'Sprained Ankle' created", time: "1 day ago" },
+    { id: 3, description: "Settings updated: Notifications enabled", time: "3 days ago" },
+  ];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Recent Activity</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {activityItems.length > 0 ? (
+          <ul className="space-y-4">
+            {activityItems.map((item) => (
+              <li key={item.id} className="flex items-center space-x-3">
+                <div className="flex-shrink-0">
+                  {/* Placeholder for an icon, e.g., based on activity type */}
+                  <span className="text-sm text-muted-foreground">●</span>
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-foreground truncate">
+                    {item.description}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {item.time}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-sm text-muted-foreground">No recent activity yet.</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/SearchBar.tsx
+++ b/src/components/dashboard/SearchBar.tsx
@@ -1,0 +1,17 @@
+import { Input } from "@/components/ui/input";
+import { Search } from "lucide-react";
+
+export function SearchBar() {
+  return (
+    <div className="relative w-full">
+      <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+        <Search className="h-5 w-5 text-muted-foreground" />
+      </div>
+      <Input
+        type="search"
+        placeholder="Search case titles and chief complaints..."
+        className="pl-10 pr-4 py-2 w-full" // Added padding for the icon and some general styling
+      />
+    </div>
+  );
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useAuth } from "@/contexts/AuthContext";
 import { Link, useLocation } from "react-router-dom";
-import { FileText, PlusCircle, X, Stethoscope } from "lucide-react";
+import { FileText, PlusCircle, X, Stethoscope, FileEdit, UserSquare, Settings as SettingsIcon } from "lucide-react";
 
 interface SidebarProps extends React.HTMLAttributes<HTMLDivElement> {
   isOpen: boolean;
@@ -20,10 +20,22 @@ const routes = [
     description: "View and manage all medical cases"
   },
   {
-    label: "New Case",
-    icon: PlusCircle,
-    href: "/cases/new",
-    description: "Create a new medical case"
+    label: "My Cases",
+    icon: UserSquare,
+    href: "/cases/my",
+    description: "Access cases assigned to you"
+  },
+  {
+    label: "Drafts",
+    icon: FileEdit,
+    href: "/cases/drafts",
+    description: "Manage your saved case drafts"
+  },
+  {
+    label: "Settings",
+    icon: SettingsIcon,
+    href: "/settings",
+    description: "Configure application settings"
   }
 ];
 

--- a/src/pages/CreateCaseFlow.tsx
+++ b/src/pages/CreateCaseFlow.tsx
@@ -1,0 +1,206 @@
+import { useState } from "react";
+import { useForm, SubmitHandler, FieldValues, Path, PathValue } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+
+import { Button } from "@/components/ui/button";
+import { FormProgressIndicator } from "@/components/cases/FormProgressIndicator";
+import { PageHeader } from "@/components/ui/page-header";
+import { FileText, User, Stethoscope, Lightbulb, AlertTriangle } from "lucide-react";
+import { Form } from "@/components/ui/form"; // Import the RHF-compatible Form component
+
+// Step Components and Schemas
+import CaseInfoStep, { caseInfoSchema, CaseInfoFormData } from "@/components/cases/create/CaseInfoStep";
+import PatientStep, { patientStepSchema, PatientStepFormData } from "@/components/cases/create/PatientStep";
+import ClinicalDetailStep, { clinicalDetailStepSchema, ClinicalDetailFormData } from "@/components/cases/create/ClinicalDetailStep";
+import LearningPointsStep, { learningPointsStepSchema, LearningPointsFormData } from "@/components/cases/create/LearningPointsStep";
+import { Card, CardContent } from "@/components/ui/card";
+
+
+// Combine Schemas
+const combinedCaseSchema = caseInfoSchema
+  .merge(patientStepSchema)
+  .merge(clinicalDetailStepSchema)
+  .merge(learningPointsStepSchema);
+
+export type CombinedCaseFormData = z.infer<typeof combinedCaseSchema>;
+
+type StepId = "caseInfo" | "patient" | "clinical" | "learning";
+
+const STEPS: { id: StepId; label: string; icon: JSX.Element; fields: Path<CombinedCaseFormData>[]; }[] = [
+  { id: "caseInfo", label: "Case Info", icon: <FileText className="h-5 w-5" />, fields: Object.keys(caseInfoSchema.shape) as Path<CombinedCaseFormData>[] },
+  { id: "patient", label: "Patient", icon: <User className="h-5 w-5" />, fields: Object.keys(patientStepSchema.shape) as Path<CombinedCaseFormData>[] },
+  { id: "clinical", label: "Clinical", icon: <Stethoscope className="h-5 w-5" />, fields: Object.keys(clinicalDetailStepSchema.shape) as Path<CombinedCaseFormData>[] },
+  { id: "learning", label: "Learning", icon: <Lightbulb className="h-5 w-5" />, fields: Object.keys(learningPointsStepSchema.shape) as Path<CombinedCaseFormData>[] },
+];
+
+const CreateCaseFlow = () => {
+  const [currentStepIndex, setCurrentStepIndex] = useState(0);
+  const [highestValidatedStep, setHighestValidatedStep] = useState(-1);
+
+
+  const form = useForm<CombinedCaseFormData>({
+    resolver: zodResolver(combinedCaseSchema),
+    mode: "onChange", // Validate on change for better UX, can also be "onBlur" or "onSubmit"
+    defaultValues: {
+      // CaseInfoStep
+      caseTitle: "",
+      chiefComplaint: "",
+      specialty: "",
+      // PatientStep
+      patientAge: undefined, // Or "" if your input handles it
+      patientSex: undefined,
+      medicalHistory: "",
+      // ClinicalDetailStep
+      selectedBodyParts: [],
+      symptoms: [],
+      relatedSystemsNotes: "",
+      vitalsNotes: "",
+      labResultsNotes: "",
+      radiologyNotes: "",
+      // LearningPointsStep
+      learningPoints: "",
+      generalNotes: "",
+      resourceLinks: [],
+    },
+  });
+
+  const { control, trigger, handleSubmit, setValue, watch, getValues }_ = form;
+
+  const handleNext = async () => {
+    const fieldsToValidate = STEPS[currentStepIndex].fields;
+    // Ensure fieldsToValidate is not empty and contains valid field names
+    if (fieldsToValidate.length > 0) {
+        const isValid = await trigger(fieldsToValidate);
+        if (!isValid) {
+        console.error("Validation failed for step:", STEPS[currentStepIndex].label, form.formState.errors);
+        return;
+        }
+    }
+    
+    setHighestValidatedStep(Math.max(highestValidatedStep, currentStepIndex));
+
+    if (currentStepIndex < STEPS.length - 1) {
+      setCurrentStepIndex((prev) => prev + 1);
+    } else {
+      // This is the final step, actual submission is handled by the form's onSubmit
+      // console.log("Attempting final submission...");
+      // await handleSubmit(onSubmit)(); // This will be called by the submit button
+    }
+  };
+
+  const handlePrevious = () => {
+    setCurrentStepIndex((prev) => Math.max(prev - 1, 0));
+  };
+
+  const handleStepClick = async (stepId: string) => {
+    const targetStepIndex = STEPS.findIndex(step => step.id === stepId);
+    if (targetStepIndex < 0 || targetStepIndex === currentStepIndex) return;
+
+    // Allow navigation to any previous step or an already validated step
+    if (targetStepIndex < currentStepIndex || targetStepIndex <= highestValidatedStep + 1) {
+        // If moving to a future unvalidated step, validate intermediate steps
+        if (targetStepIndex > currentStepIndex && targetStepIndex > highestValidatedStep) {
+            for (let i = currentStepIndex; i < targetStepIndex; i++) {
+                const fieldsToValidate = STEPS[i].fields;
+                if (fieldsToValidate.length > 0) {
+                    const isValid = await trigger(fieldsToValidate);
+                    if (!isValid) {
+                        setCurrentStepIndex(i); // Stay on the step that failed validation
+                        console.error("Validation failed when trying to jump to step:", STEPS[i].label, form.formState.errors);
+                        return;
+                    }
+                    setHighestValidatedStep(Math.max(highestValidatedStep, i));
+                }
+            }
+        }
+        setCurrentStepIndex(targetStepIndex);
+    } else {
+        // Optionally, provide feedback that user needs to complete current/intermediate steps
+        console.log("Please complete the current step before moving to a future unvalidated step.");
+    }
+  };
+  
+  const onSubmit: SubmitHandler<CombinedCaseFormData> = (data) => {
+    console.log("Form Submitted Successfully!");
+    console.log("Data:", data);
+    // Here you would typically send the data to your backend
+    // e.g., await api.createCase(data);
+    alert("Case submitted! Check console for data.");
+  };
+
+  const currentStepData = STEPS[currentStepIndex];
+  const isLastStep = currentStepIndex === STEPS.length - 1;
+
+  const renderStepContent = () => {
+    switch (STEPS[currentStepIndex].id) {
+      case "caseInfo":
+        return <CaseInfoStep control={control} />;
+      case "patient":
+        return <PatientStep control={control} />;
+      case "clinical":
+        return <ClinicalDetailStep control={control} setValue={setValue as UseFormSetValue<FieldValues>} watch={watch} />;
+      case "learning":
+        return <LearningPointsStep control={control} />;
+      default:
+        return (
+            <Card className="border-destructive bg-destructive/10">
+                <CardContent className="p-6 flex flex-col items-center text-center">
+                    <AlertTriangle className="h-12 w-12 text-destructive mb-4" />
+                    <h2 className="text-xl font-semibold text-destructive mb-2">Error</h2>
+                    <p className="text-destructive/80">Invalid step. Please refresh or contact support.</p>
+                </CardContent>
+            </Card>
+        );
+    }
+  };
+
+  return (
+    <div className="container mx-auto py-8 space-y-8 px-4 md:px-0">
+      <PageHeader 
+        title="Create New Clinical Case"
+        description={`Step ${currentStepIndex + 1} of ${STEPS.length}: ${currentStepData.label}`}
+      />
+
+      <FormProgressIndicator
+        currentStep={currentStepIndex + 1}
+        totalSteps={STEPS.length}
+        steps={STEPS.map((step, index) => ({ 
+            id: step.id, 
+            label: step.label, 
+            icon: step.icon,
+            isCompleted: index <= highestValidatedStep,
+            isNavigable: index <= highestValidatedStep + 1 || index < currentStepIndex,
+        }))}
+        onStepClick={handleStepClick}
+      />
+      
+      <Form {...form}> {/* Spread RHF props to the Form component */}
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+          <div className="p-6 border border-border rounded-lg min-h-[350px] bg-card shadow-sm">
+            {renderStepContent()}
+          </div>
+
+          <div className="flex justify-between items-center pt-4 border-t border-border">
+            <Button
+              type="button"
+              onClick={handlePrevious}
+              disabled={currentStepIndex === 0}
+              variant="outline"
+            >
+              Previous
+            </Button>
+            <div className="text-sm text-muted-foreground">
+              Step {currentStepIndex + 1} of {STEPS.length}
+            </div>
+            <Button type={isLastStep ? "submit" : "button"} onClick={!isLastStep ? handleNext : undefined} variant="default">
+              {isLastStep ? "Submit Case" : "Next"}
+            </Button>
+          </div>
+        </form>
+      </Form>
+    </div>
+  );
+};
+
+export default CreateCaseFlow;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,200 +1,47 @@
-
 import { PageHeader } from "@/components/ui/page-header";
-import { StatCard } from "@/components/dashboard/StatCard";
-import { RecentCasesList } from "@/components/dashboard/RecentCasesList";
-import { useSupabaseCases } from "@/hooks/use-supabase-cases";
-import { Button } from "@/components/ui/button";
-import { Link } from "react-router-dom";
-import { 
-  ClipboardList, 
-  BookOpen, 
-  FileText, 
-  Calendar,
-  UserRound
-} from "lucide-react";
-import {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardContent
-} from "@/components/ui/card";
+import { ActiveCasesWidget } from "@/components/dashboard/ActiveCasesWidget";
+import { DraftsWidget } from "@/components/dashboard/DraftsWidget";
+import { CompletedWidget } from "@/components/dashboard/CompletedWidget";
+import { RecentActivity } from "@/components/dashboard/RecentActivity";
+import { SearchBar } from "@/components/dashboard/SearchBar";
+import { QuickStartPanel } from "@/components/dashboard/QuickStartPanel";
+import { UserRound } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { LoadingSpinner } from "@/components/ui/loading-spinner";
-import { Progress } from "@/components/ui/progress";
 
 const Dashboard = () => {
-  const { cases, isLoading, error } = useSupabaseCases();
-  
-  if (isLoading) {
-    return (
-      <div className="flex items-center justify-center min-h-screen">
-        <LoadingSpinner size="lg" />
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="flex items-center justify-center min-h-screen">
-        <Alert className="border-destructive/20 bg-destructive/5">
-          <AlertDescription className="text-destructive">
-            Error loading cases: {error.message}
-          </AlertDescription>
-        </Alert>
-      </div>
-    );
-  }
-
-  // Get recent cases (last 5 by updated date)
-  const recentCases = cases.slice(0, 5);
-  
-  const stats = [
-    {
-      title: "Total Cases",
-      value: cases.length,
-      icon: <ClipboardList className="h-4 w-4" />,
-      description: "Documented patient cases",
-    },
-    {
-      title: "Study Resources",
-      value: cases.reduce((acc, curr) => acc + curr.resources.length, 0),
-      icon: <BookOpen className="h-4 w-4" />,
-      description: "Linked learning materials",
-    },
-    {
-      title: "Learning Notes",
-      value: cases.filter(c => c.learningPoints && c.learningPoints.length > 0).length,
-      icon: <FileText className="h-4 w-4" />,
-      description: "Cases with learning points",
-    },
-    {
-      title: "This Week",
-      value: cases.filter(c => {
-        const date = new Date(c.createdAt);
-        const now = new Date();
-        const weekAgo = new Date();
-        weekAgo.setDate(now.getDate() - 7);
-        return date >= weekAgo && date <= now;
-      }).length,
-      icon: <Calendar className="h-4 w-4" />,
-      description: "New cases this week",
-    },
-  ];
-
-  // Calculate specialty progress based on tags
-  const specialtyProgress = cases.reduce((acc, caseItem) => {
-    caseItem.tags.forEach(tag => {
-      if (!acc[tag.name]) {
-        acc[tag.name] = 0;
-      }
-      acc[tag.name]++;
-    });
-    return acc;
-  }, {} as Record<string, number>);
-
-  const topSpecialties = Object.entries(specialtyProgress)
-    .sort(([,a], [,b]) => b - a)
-    .slice(0, 3);
-
   return (
     <div className="space-y-6">
-      <Alert className="border-primary/20 bg-primary/5 mb-6">
+      {/* Welcome Alert - Can be kept or modified as per overall design */}
+      <Alert className="border-primary/20 bg-primary/5">
         <UserRound className="h-5 w-5 text-primary" />
         <AlertDescription className="text-primary">
-          Welcome to Clinical Case Manager! This application was created by <strong>Alwaleed Alabdali</strong> for medical students to document and learn from clinical cases.
+          Welcome back! This is your central hub for managing clinical cases.
         </AlertDescription>
       </Alert>
-      
+
       <PageHeader 
-        title="Medical Case Manager" 
-        description="Document and learn from clinical cases"
-      >
-        <Button asChild>
-          <Link to="/cases/new">
-            <ClipboardList className="mr-2 h-4 w-4" />
-            Add New Case
-          </Link>
-        </Button>
-      </PageHeader>
+        title="Dashboard" 
+        description="Overview of your clinical case activities."
+      />
       
-      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
-        {stats.map((stat) => (
-          <StatCard
-            key={stat.title}
-            title={stat.title}
-            value={stat.value}
-            icon={stat.icon}
-            description={stat.description}
-          />
-        ))}
+      <div className="mb-6">
+        <SearchBar />
       </div>
       
-      <RecentCasesList cases={recentCases} />
+      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3 mb-6">
+        <ActiveCasesWidget />
+        <DraftsWidget />
+        <CompletedWidget />
+      </div>
       
-      <div className="grid gap-6 md:grid-cols-2">
-        <Card className="hover:shadow-md transition-shadow">
-          <CardHeader className="pb-3">
-            <CardTitle className="text-lg font-semibold">Quick Start</CardTitle>
-          </CardHeader>
-          <CardContent className="pt-0 space-y-3">
-            <Button variant="outline" asChild className="w-full justify-start mb-2">
-              <Link to="/cases/new">
-                <ClipboardList className="mr-2 h-4 w-4" /> 
-                Document a new case
-              </Link>
-            </Button>
-            <Button variant="outline" asChild className="w-full justify-start mb-2">
-              <Link to="/resources">
-                <BookOpen className="mr-2 h-4 w-4" /> 
-                Browse study resources
-              </Link>
-            </Button>
-            <Button variant="outline" asChild className="w-full justify-start">
-              <Link to="/study">
-                <FileText className="mr-2 h-4 w-4" /> 
-                Generate practice questions
-              </Link>
-            </Button>
-          </CardContent>
-        </Card>
-        
-        <Card className="hover:shadow-md transition-shadow">
-          <CardHeader className="pb-3">
-            <CardTitle className="text-lg font-semibold">Study Progress</CardTitle>
-          </CardHeader>
-          <CardContent className="pt-0 space-y-4">
-            <div className="space-y-3">
-              {topSpecialties.length > 0 ? (
-                topSpecialties.map(([specialty, count]) => (
-                  <div key={specialty} className="space-y-2">
-                    <div className="flex justify-between text-sm">
-                      <span className="font-medium">{specialty}</span>
-                      <span className="text-muted-foreground">{count} case{count !== 1 ? 's' : ''}</span>
-                    </div>
-                    <Progress 
-                      value={cases.length > 0 ? Math.min((count / cases.length) * 100, 100) : 0} 
-                      className="h-2"
-                    />
-                  </div>
-                ))
-              ) : (
-                <div className="space-y-2">
-                  <div className="flex justify-between text-sm">
-                    <span className="font-medium">No specialties yet</span>
-                    <span className="text-muted-foreground">0 cases</span>
-                  </div>
-                  <Progress value={0} className="h-2" />
-                </div>
-              )}
-            </div>
-            <div className="text-sm text-muted-foreground bg-accent/30 p-3 rounded-md">
-              {cases.length === 0 
-                ? "Start adding cases to track your progress across specialties"
-                : "Add more cases and tags to track your progress across specialties"
-              }
-            </div>
-          </CardContent>
-        </Card>
+      <div className="grid gap-6 lg:grid-cols-3">
+        {/* Main Content Area: QuickStartPanel (taking 2/3 width) and RecentActivity (taking 1/3 width) */}
+        <div className="lg:col-span-2">
+          <QuickStartPanel />
+        </div>
+        <div className="lg:col-span-1">
+          <RecentActivity />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
This commit introduces a redesigned landing dashboard and a new four-step process for creating clinical cases.

Key changes:

1.  **New Dashboard (`src/pages/Dashboard.tsx`):**
    *   Replaced the old dashboard with a new layout.
    *   Added new components:
        *   `ActiveCasesWidget`, `DraftsWidget`, `CompletedWidget` for overview stats.
        *   `RecentActivity` widget.
        *   `SearchBar` (visual placeholder).
        *   `QuickStartPanel` with a "+ New Clinical Case" button and draft case placeholders.
    *   Updated `Sidebar.tsx` with new navigation links: "My Cases", "Drafts", "Settings", and removed "New Case".
    *   Currently, dashboard components use placeholder data.

2.  **Refactored Case Creation (`src/pages/CreateCaseFlow.tsx`):**
    *   Replaced the old two-step `CaseNew.tsx` with a new four-step flow.
    *   Created individual components for each step:
        *   `CaseInfoStep.tsx` (Title, Chief Complaint, Specialty)
        *   `PatientStep.tsx` (Age, Sex, Medical History)
        *   `ClinicalDetailStep.tsx` (Body Diagram, Symptoms, Clinical Notes)
        *   `LearningPointsStep.tsx` (Learning Points, Notes, Resources)
    *   Integrated `react-hook-form` with Zod schemas for each step and a combined schema for the entire form.
    *   Implemented step-to-step navigation with validation and a progress indicator.
    *   The form data is currently logged to the console upon submission; backend integration is pending.

This work completes the client-side UI and logic for the new dashboard and case creation process as per the initial plan. The next steps will involve API and data model adjustments to support these new features.