### PR TITLE
Refactor: Standardize project naming and metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 clinical-case-compass
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Clinical Case Simulation Platform
+# Clinical Case Compass
 
 ## Description
 
@@ -42,7 +42,7 @@ Follow these steps to get a local copy of the project up and running.
 
 ```bash
 git clone <repository_url>
-cd vite_react_shadcn_ts # Or your chosen directory name
+cd clinical-case-compass # Or your chosen directory name
 ```
 
 ### 2. Install Dependencies
@@ -101,7 +101,7 @@ If using Bun, replace `npm run` with `bun run`.
 ## Project Structure
 
 ```
-vite_react_shadcn_ts/
+clinical-case-compass/
 ├── .github/                            # GitHub Actions workflows (e.g., CI, summary.yml)
 ├── public/                             # Static assets (favicon, placeholder images, robots.txt)
 ├── src/                                # Source code

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "vite_react_shadcn_ts",
+  "name": "clinical-case-compass",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
This commit addresses several repository initialization and cleanup tasks:

- Updated `package.json`:
    - Set project name to `clinical-case-compass`.
    - Bumped version to `0.5.0`.
- Updated `README.md`:
    - Changed project title to `Clinical Case Compass`.
    - Updated directory references from `vite_react_shadcn_ts` to `clinical-case-compass` in "Getting Started" and "Project Structure" sections.
- Added `LICENSE` file:
    - Included the standard MIT License text.
    - Set copyright to "2024 clinical-case-compass".
- Verified CI/CD paths in `.github/workflows/*` require no changes.