### PR TITLE
Fix: Improve AppLayout responsiveness and spacing

### DIFF
--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -12,12 +12,15 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children, className }) => 
   return (
     <div className="min-h-screen bg-background">
       <Sidebar />
-      <main className={cn(
-        "transition-all duration-300 ease-in-out",
-        "lg:pl-64", // Always account for sidebar on large screens
-        "flex flex-col",
-        className
-      )}>
+      <main
+        className={cn(
+          "transition-all duration-300 ease-in-out",
+          // "lg:pl-64", // This line is removed
+          "flex flex-col",
+          className
+        )}
+        style={{ paddingLeft: 'var(--current-sidebar-offset, 0px)' }}
+      >
         <div className="flex-1">
           <div className="container space-y-6">
             {children}

--- a/src/layouts/Sidebar.tsx
+++ b/src/layouts/Sidebar.tsx
@@ -200,10 +200,17 @@ export const Sidebar = forwardRef<HTMLDivElement, SidebarProviderProps>(
       [state, open, setOpen, isMobile, openMobile, toggleSidebar]
     );
 
+    const currentSidebarOffset = isMobile
+      ? "0px"
+      : open
+      ? SIDEBAR_CONFIG.WIDTH
+      : SIDEBAR_CONFIG.WIDTH_ICON;
+
     const cssVariables = {
       "--sidebar-width": SIDEBAR_CONFIG.WIDTH,
       "--sidebar-width-icon": SIDEBAR_CONFIG.WIDTH_ICON,
       "--sidebar-width-mobile": SIDEBAR_CONFIG.WIDTH_MOBILE,
+      "--current-sidebar-offset": currentSidebarOffset,
       ...style,
     } as React.CSSProperties;
 


### PR DESCRIPTION
This commit enhances the AppLayout component to provide better transitions and consistent spacing for the main content area in relation to the sidebar across various screen sizes.

Key changes:

1.  **Dynamic Sidebar Offset:** The `Sidebar` component now exposes a CSS variable (`--current-sidebar-offset`) that reflects its effective width based on its current state:
    *   `0px` on mobile views (where the sidebar is a sheet overlay).
    *   `16rem` (expanded width) on desktop/tablet views when the sidebar is open.
    *   `3rem` (collapsed/icon width) on desktop/tablet views when the sidebar is closed.

2.  **Adaptive Main Content Padding:** The `AppLayout` component's `main` content area now uses this `--current-sidebar-offset` CSS variable to dynamically set its `padding-left`. This replaces the previous static `lg:pl-64` Tailwind utility.

These changes ensure that:
- The main content area correctly adjusts its spacing when the sidebar is toggled (expanded/collapsed) on desktop and tablet views (screen widths >= 768px).
- The problematic spacing issue on tablet sizes (between 768px and 1024px), where the desktop sidebar might have been active without the corresponding content padding, is resolved.
- Transitions for padding changes are handled smoothly by the existing CSS transition properties on the main content element.