### PR TITLE
Fix: Improve layout and responsiveness of Cases page

### DIFF
--- a/src/features/cases/CaseCard.tsx
+++ b/src/features/cases/CaseCard.tsx
@@ -83,7 +83,7 @@ export const CaseCard: React.FC<CaseCardProps> = memo(
             </time>
           </div>
 
-          <div className="mt-2 flex items-center text-sm md:text-base text-muted-foreground">
+          <div className="mt-2 flex items-center text-sm md:text-base text-muted-foreground truncate">
             <User className="mr-2 h-4 w-4 flex-shrink-0" aria-hidden />
             {medicalCase.patient.name}, {medicalCase.patient.age} y/o {medicalCase.patient.gender}
           </div>

--- a/src/features/cases/CaseListItem.tsx
+++ b/src/features/cases/CaseListItem.tsx
@@ -25,7 +25,7 @@ export const CaseListItem = memo<CaseListItemProps>(({ medicalCase, className, o
   return (
     <Card className={cn("hover:shadow-md transition-shadow", className)}>
       <CardContent className="p-4">
-        <div className="flex items-start justify-between gap-4"> {/* Main flex container: items-start for alignment if content heights differ */}
+        <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4"> {/* Main flex container: items-start for alignment if content heights differ */}
           
           {/* Left Section: Main Info (takes up more space) */}
           <div className="flex-grow space-y-2 min-w-0"> {/* min-w-0 for proper truncation */}
@@ -52,7 +52,7 @@ export const CaseListItem = memo<CaseListItemProps>(({ medicalCase, className, o
           </div>
 
           {/* Right Section: Tags & Actions (fixed width or shrinks less) */}
-          <div className="flex-shrink-0 flex flex-col items-end space-y-2">
+          <div className="flex-shrink-0 flex flex-col items-start sm:items-end space-y-2 w-full sm:w-auto">
             {/* Tags */}
             <div className="flex items-center gap-2">
               {primaryTag && (

--- a/src/pages/Cases.tsx
+++ b/src/pages/Cases.tsx
@@ -82,7 +82,7 @@ const Cases = () => {
           </CardContent>
         </Card>
       ) : (
-        <div className={viewMode === "grid" ? "grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4" : ""}>
+        <div className={viewMode === "grid" ? "grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4" : "space-y-4"}>
           {viewMode === "grid" ? (
             filteredCases.map((caseItem) => (
               <CaseCard key={caseItem.id} medicalCase={caseItem} />


### PR DESCRIPTION
This commit enhances the layout, orientation, and responsiveness of the /cases page, addressing issues in both grid and list views.

Key changes include:

- **Cases Page (`Cases.tsx`):**
  - Added `space-y-4` to the list view wrapper for consistent vertical spacing between case list items.

- **Case Card (`CaseCard.tsx`):**
  - Added `truncate` to the patient information line to prevent overflow on smaller card sizes within the grid.
  - Reviewed and confirmed existing responsive text sizes, line-clamping, and icon alignments.

- **Case List Item (`CaseListItem.tsx`):**
  - Implemented responsive layout changes:
    - The main content sections now stack vertically (`flex-col`) on small screens and switch to a horizontal layout (`sm:flex-row`) on larger screens.
    - The tags and actions section alignment and width (`items-start sm:items-end w-full sm:w-auto`) adjust for optimal presentation in both stacked and row modes.
  - Reviewed and confirmed existing text truncation, responsive text/icon sizes, and general content presentation.

These changes aim to provide a more robust and user-friendly experience across various screen sizes and devices when viewing the list of cases.