### PR TITLE
Fix: Improve responsiveness of new case form (/cases/new)

### DIFF
--- a/src/features/cases/FormProgressIndicator.tsx
+++ b/src/features/cases/FormProgressIndicator.tsx
@@ -43,7 +43,7 @@ export function FormProgressIndicator({
         indicatorClassName="bg-primary"
       />
       
-      <div className="flex justify-between mt-2">
+      <div className="flex justify-between flex-wrap mt-2">
         {steps.map((step, index) => {
           const isActive = index + 1 === currentStep;
           const isCompleted = step.isCompleted || index + 1 < currentStep;

--- a/src/features/cases/create/FormContainer.tsx
+++ b/src/features/cases/create/FormContainer.tsx
@@ -49,7 +49,7 @@ export const FormContainer: React.FC<FormContainerProps> = memo(
           <CardContent className="p-6">
             {/* Reserve vertical space so the overall layout doesn't jump between   */}
             {/* steps of varying height. Adjust `min-h` as needed for your design. */}
-            <div>{children}</div>
+            <div className="min-h-[60vh]">{children}</div>
           </CardContent>
         </Card>
       </section>

--- a/src/features/cases/create/FormNavigation.tsx
+++ b/src/features/cases/create/FormNavigation.tsx
@@ -69,7 +69,7 @@ export const FormNavigation: React.FC<FormNavigationProps> = memo(
                 <span className="mt-1 text-xs">{currentStepLabel}</span>
               )}
               {/* Linear progress bar */}
-              <div className="mt-2 h-1.5 w-40 overflow-hidden rounded bg-muted">
+              <div className="mt-2 h-1.5 w-full overflow-hidden rounded bg-muted">
                 <div
                   className="h-full bg-primary transition-all"
                   style={{ width: `${(currentStep / totalSteps) * 100}%` }}


### PR DESCRIPTION
This commit addresses layout and orientation issues on the multi-step new case form page (/cases/new), focusing on better adaptability to various screen sizes.

Key changes include:

- **FormProgressIndicator.tsx:**
  - Added `flex-wrap` to the container of the step indicator buttons. This allows the buttons to wrap onto multiple lines on smaller screens, preventing horizontal overflow and improving usability when there are several steps.

- **FormNavigation.tsx:**
  - Changed the fixed width (`w-40`) of the linear progress bar in the bottom navigation to `w-full`. This makes the progress bar responsive, allowing it to resize appropriately based on the available space within its flex container, especially on narrower screens.

- **FormContainer.tsx:**
  - Added a `min-h-[60vh]` to the main content area that wraps each form step. This UX refinement helps to stabilize the position of the bottom navigation, reducing the "jumping" effect when switching between steps of different content heights.

These changes ensure that the header, step indicators, main form content, and navigation controls of the new case form are better presented and more accessible across a range of devices.