### PR TITLE
Fix TypeScript module and export errors

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,14 +1,14 @@
 
-import { Toaster } from "@/shared/ui/toaster";
-import { Toaster as Sonner } from "@/shared/ui/sonner";
-import { TooltipProvider } from "@/shared/ui/tooltip";
+import { Toaster } from "@/components/ui/toaster";
+import { Toaster as Sonner } from "@/components/ui/sonner";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { SidebarProvider } from "@/features/navigation";
 import { AppLayout } from "@/features/navigation";
 import { AuthProvider } from "./AuthContext";
 import { ThemeProvider } from "./ThemeContext";
-import { ErrorBoundary } from "@/shared/ui/error-boundary";
+import { ErrorBoundary } from "@/components/error/ErrorBoundary";
 import Dashboard from "@/pages/Dashboard";
 import Cases from "@/pages/Cases";
 import CaseDetail from "@/pages/CaseDetail";

--- a/src/features/cases/new/components/CaseInfoStep.tsx
+++ b/src/features/cases/new/components/CaseInfoStep.tsx
@@ -8,17 +8,17 @@ import {
   FormControl,
   FormDescription,
   FormMessage,
-} from "@/shared/ui/form";
-import { Input } from "@/shared/ui/input";
-import { Textarea } from "@/shared/ui/textarea";
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@/shared/ui/select";
-import { Card, CardContent, CardHeader, CardTitle } from "@/shared/ui/card";
+} from "@/components/ui/select";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { FileText, Stethoscope, Tag } from "lucide-react";
 import { cn } from "@/shared/utils";
 

--- a/src/features/cases/new/components/FormContainer.tsx
+++ b/src/features/cases/new/components/FormContainer.tsx
@@ -1,5 +1,5 @@
 import React, { memo, ReactNode } from "react";
-import { Card, CardContent } from "@/shared/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { FormProgressIndicator } from "@/features/cases/FormProgressIndicator";
 import { cn } from "@/shared/utils";
 

--- a/src/features/cases/new/index.ts
+++ b/src/features/cases/new/index.ts
@@ -1,8 +1,12 @@
 
 export { CaseInfoStep } from './components/CaseInfoStep';
-export { PatientStep } from './components/PatientStep';
-export { ClinicalDetailStep } from './components/ClinicalDetailStep';
-export { LearningPointsStep } from './components/LearningPointsStep';
+export { caseInfoSchema } from './components/CaseInfoStep';
+export { PatientStep } from '../create/PatientStep';
+export { patientStepSchema } from '../create/PatientStep';
+export { ClinicalDetailStep } from '../create/ClinicalDetailStep';
+export { clinicalDetailStepSchema } from '../create/ClinicalDetailStep';
+export { LearningPointsStep } from '../create/LearningPointsStep';
+export { learningPointsStepSchema } from '../create/LearningPointsStep';
 export { FormContainer } from './components/FormContainer';
-export { FormHeader } from './components/FormHeader';
-export { FormNavigation } from './components/FormNavigation';
+export { FormHeader } from '../create/FormHeader';
+export { FormNavigation } from '../create/FormNavigation';

--- a/src/features/dashboard/components/ActiveCasesWidget.tsx
+++ b/src/features/dashboard/components/ActiveCasesWidget.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from "@/shared/ui/card";
-import { Badge } from "@/shared/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 import { Clock, TrendingUp } from "lucide-react";
 
 export const ActiveCasesWidget = () => {

--- a/src/features/dashboard/components/CompletedWidget.tsx
+++ b/src/features/dashboard/components/CompletedWidget.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from "@/shared/ui/card";
-import { Badge } from "@/shared/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 import { CheckCircle, Trophy } from "lucide-react";
 
 export const CompletedWidget = () => {

--- a/src/features/dashboard/components/DraftsWidget.tsx
+++ b/src/features/dashboard/components/DraftsWidget.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from "@/shared/ui/card";
-import { Badge } from "@/shared/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 import { FileText, Edit } from "lucide-react";
 
 export const DraftsWidget = () => {

--- a/src/features/dashboard/components/QuickStartPanel.tsx
+++ b/src/features/dashboard/components/QuickStartPanel.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from "@/shared/ui/card";
-import { Button } from "@/shared/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 import { Plus, BookOpen, Users, Settings } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/features/dashboard/components/RecentActivity.tsx
+++ b/src/features/dashboard/components/RecentActivity.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from "@/shared/ui/card";
-import { Badge } from "@/shared/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 import { Clock, User, FileText, CheckCircle2 } from "lucide-react";
 
 const recentItems = [

--- a/src/features/dashboard/components/SearchBar.tsx
+++ b/src/features/dashboard/components/SearchBar.tsx
@@ -1,8 +1,8 @@
 
 import React from 'react';
 import { Search } from "lucide-react";
-import { Input } from "@/shared/ui/input";
-import { Card, CardContent } from "@/shared/ui/card";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent } from "@/components/ui/card";
 
 export const SearchBar = () => {
   return (

--- a/src/features/navigation/components/Sidebar.tsx
+++ b/src/features/navigation/components/Sidebar.tsx
@@ -14,7 +14,7 @@ import {
   SheetHeader,
   SheetTitle,
   SheetTrigger,
-} from "@/shared/ui/sheet";
+} from "@/components/ui/sheet";
 import {
   NavigationMenu,
   NavigationMenuContent,
@@ -23,7 +23,7 @@ import {
   NavigationMenuList,
   NavigationMenuTrigger,
   navigationMenuTriggerStyle,
-} from "@/shared/ui/navigation-menu";
+} from "@/components/ui/navigation-menu";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -31,12 +31,12 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-} from "@/shared/ui/dropdown-menu";
+} from "@/components/ui/dropdown-menu";
 import {
   Avatar,
   AvatarFallback,
   AvatarImage,
-} from "@/shared/ui/avatar";
+} from "@/components/ui/avatar";
 import {
   Bell,
   Menu,
@@ -52,8 +52,8 @@ import {
 } from "lucide-react";
 import { cn } from "@/shared/utils";
 import { Link, useLocation, useNavigate } from "react-router-dom";
-import { Button } from "@/shared/ui/button";
-import { AuthContext } from "@/app/AuthContext";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/app/AuthContext";
 
 const SidebarContext = createContext({
   state: "collapsed",
@@ -172,7 +172,7 @@ const navItems = [
 
 export const Sidebar = React.memo(function Sidebar() {
   const { state, isMobile } = useSidebar();
-  const { signOut } = useContext(AuthContext);
+  const { user, signOut } = useAuth();
   const navigate = useNavigate();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
@@ -200,10 +200,10 @@ export const Sidebar = React.memo(function Sidebar() {
           <DropdownMenuLabel className="font-normal">
             <div className="flex flex-col space-y-1">
               <span className="text-sm font-medium leading-none">
-                shadcn
+                {user?.displayName || "User"}
               </span>
               <span className="text-xs leading-none text-muted-foreground">
-                shad.cn@gmail.com
+                {user?.email || "user@example.com"}
               </span>
             </div>
           </DropdownMenuLabel>
@@ -221,7 +221,7 @@ export const Sidebar = React.memo(function Sidebar() {
             <span>Support</span>
           </DropdownMenuItem>
           <DropdownMenuSeparator />
-          <DropdownMenuItem className="cursor-pointer" onClick={handleSignOut}>
+          <DropdownMenuItem className="cursor-pointer" onSelect={handleSignOut}>
             <LogOut className="mr-2 h-4 w-4" />
             <span>Log out</span>
           </DropdownMenuItem>

--- a/src/pages/CreateCaseFlow.tsx
+++ b/src/pages/CreateCaseFlow.tsx
@@ -4,7 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 
 import { FileText, User, Stethoscope, Lightbulb, AlertTriangle } from "lucide-react";
-import { Form } from "@/shared/ui/form";
+import { Form } from "@/components/ui/form";
 import { toast } from "sonner";
 
 // Step Components and Schemas - updated imports
@@ -22,7 +22,7 @@ import {
   learningPointsStepSchema
 } from "@/features/cases/new";
 
-import { Card, CardContent } from "@/shared/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 
 // Combine Schemas
 const combinedCaseSchema = caseInfoSchema

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 
-import { PageHeader } from "@/shared/ui/page-header";
+import { PageHeader } from "@/components/ui/page-header";
 import { 
   ActiveCasesWidget,
   DraftsWidget,
@@ -9,7 +9,7 @@ import {
   QuickStartPanel
 } from "@/features/dashboard";
 import { UserRound } from "lucide-react";
-import { Alert, AlertDescription } from "@/shared/ui/alert";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 
 const Dashboard = () => {
   return (


### PR DESCRIPTION
This commit resolves a series of TypeScript errors that were preventing the application from compiling successfully.

The main fixes include:
- Corrected AuthContext usage in Sidebar.tsx to use the `useAuth` hook, resolving TS2459 and TS2339.
- Updated import paths for UI components from `@/shared/ui/...` to `@/components/ui/...` and corrected the specific path for ErrorBoundary to `@/components/error/ErrorBoundary`. This fixed numerous TS2307 errors.
- Fixed incorrect component import paths in `src/features/cases/new/index.ts`. Components like PatientStep, ClinicalDetailStep, etc., were being looked for in `./components/` but are located in `../create/`. The paths have been updated.
- Added missing schema exports (`caseInfoSchema`, `patientStepSchema`, `clinicalDetailStepSchema`, `learningPointsStepSchema`) from `src/features/cases/new/index.ts`. These schemas are defined in their respective component files (either in `src/features/cases/new/components` or `src/features/cases/create`) and now are correctly re-exported. This resolved TS2305 and TS2724 errors.