### PR TITLE
Fix system symptoms restoration in CaseEdit

### DIFF
--- a/src/pages/CaseEdit.tsx
+++ b/src/pages/CaseEdit.tsx
@@ -127,6 +127,10 @@ const CaseEdit = () => {
     if (foundCase.symptoms) {
       setSymptoms(foundCase.symptoms);
     }
+
+    if (foundCase.systemSymptoms) {
+      setSystemSymptoms(foundCase.systemSymptoms);
+    }
     
     if (foundCase.labTests) {
       setLabResults(foundCase.labTests);


### PR DESCRIPTION
## Summary
- restore `foundCase.systemSymptoms` when loading a case in edit page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68404c5c705c832e9232f1c8e6f73af1