### PR TITLE
Refactor body diagram components

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ clinical-case-compass/
 ├── src/                                # Source code
 │   ├── components/                     # React components
 │   │   ├── auth/                       # Authentication-related components (UserProfileDisplay, PrivateRoute)
-│   │   ├── cases/                      # Case specific components (e.g., CaseCard, SimpleBodyPartSelector, the complex SVG InteractiveBodyDiagram, SymptomChecklist)
+│   │   ├── body-diagram/              # SimpleBodyPartSelector component
+│   │   ├── cases/                      # Case specific components (e.g., CaseCard, SymptomChecklist)
 │   │   ├── dashboard/                  # Dashboard specific components (e.g., RecentCasesList, StatCard, DashboardSearchBar)
 │   │   ├── error/                      # Error handling (ErrorBoundary)
 │   │   └── ui/                         # Core UI components from Shadcn/ui (Button, Card, Input, etc.)
@@ -144,9 +145,9 @@ clinical-case-compass/
 ```
 
 **Note on Body Diagram Components:**
-The `src/components/cases/` directory contains two distinct components for body part interaction:
-*   `InteractiveBodyDiagram.tsx`: A complex, SVG-based visual diagram with features like zoom and anterior/posterior views.
-*   `SimpleBodyPartSelector.tsx`: A lightweight component that provides a list of buttons for selecting general body regions.
+This project offers two components for selecting body regions:
+* `src/features/cases/InteractiveBodyDiagram.tsx` – a full SVG diagram with zoom and anterior/posterior views.
+* `src/components/body-diagram/SimpleBodyPartSelector.tsx` – a lightweight list of buttons for quick selection.
 
 ## Contributing
 

--- a/src/components/body-diagram/SimpleBodyPartSelector.tsx
+++ b/src/components/body-diagram/SimpleBodyPartSelector.tsx
@@ -75,7 +75,7 @@ const BODY_PART_CONFIG: Record<BodyPart, BodyPartConfig> = {
   }
 } as const;
 
-export interface InteractiveBodyDiagramProps {
+export interface SimpleBodyPartSelectorProps {
   /** Callback when body parts are selected/deselected */
   onSelectionChange: (selectedParts: BodyPart[]) => void;
   /** Initially selected body parts */
@@ -97,7 +97,7 @@ export interface InteractiveBodyDiagramProps {
 /**
  * Enhanced interactive body diagram with improved UX, accessibility, and functionality
  */
-export const InteractiveBodyDiagram: React.FC<InteractiveBodyDiagramProps> = React.memo(({
+export const SimpleBodyPartSelector: React.FC<SimpleBodyPartSelectorProps> = React.memo(({
   onSelectionChange,
   initialSelection = [],
   highlightedParts = [],
@@ -344,20 +344,20 @@ export const InteractiveBodyDiagram: React.FC<InteractiveBodyDiagramProps> = Rea
   );
 });
 
-InteractiveBodyDiagram.displayName = "InteractiveBodyDiagram";
+SimpleBodyPartSelector.displayName = "SimpleBodyPartSelector";
 
 // Usage examples:
 export const BodyDiagramExamples = {
   // Basic usage
   Basic: () => (
-    <InteractiveBodyDiagram 
+    <SimpleBodyPartSelector
       onSelectionChange={(parts) => console.log('Selected:', parts)}
     />
   ),
 
   // Single selection mode
   SingleSelect: () => (
-    <InteractiveBodyDiagram 
+    <SimpleBodyPartSelector
       onSelectionChange={(parts) => console.log('Selected:', parts)}
       multiSelect={false}
     />
@@ -365,7 +365,7 @@ export const BodyDiagramExamples = {
 
   // Compact mode
   Compact: () => (
-    <InteractiveBodyDiagram 
+    <SimpleBodyPartSelector
       onSelectionChange={(parts) => console.log('Selected:', parts)}
       compact={true}
     />
@@ -373,7 +373,7 @@ export const BodyDiagramExamples = {
 
   // With initial selection and highlights
   Advanced: () => (
-    <InteractiveBodyDiagram 
+    <SimpleBodyPartSelector
       onSelectionChange={(parts) => console.log('Selected:', parts)}
       initialSelection={["Head", "Chest"]}
       highlightedParts={["Arms", "Legs"]}


### PR DESCRIPTION
## Summary
- remove unused body diagram implementation
- rename simple selector to `SimpleBodyPartSelector`
- clarify body diagram component locations in docs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408b5c2cf8832eb099854f17194830