### PR TITLE
Fix collapsed sidebar nav item sizing

### DIFF
--- a/src/features/navigation/components/Sidebar.tsx
+++ b/src/features/navigation/components/Sidebar.tsx
@@ -240,7 +240,7 @@ export const Sidebar = React.memo(function Sidebar() {
       <TooltipTrigger asChild>
         <Link
           to={item.href}
-          className="group flex h-[70px] w-[70px] flex-col items-center justify-center rounded-md text-muted-foreground outline-none data-[active=true]:bg-accent data-[active=true]:text-accent-foreground"
+          className="group flex h-[var(--sidebar-width-icon)] w-[var(--sidebar-width-icon)] flex-col items-center justify-center rounded-md text-muted-foreground outline-none data-[active=true]:bg-accent data-[active=true]:text-accent-foreground"
           data-active={location.pathname === item.href}
           aria-label={item.label}
           ref={index === 0 ? firstLinkRef : undefined}


### PR DESCRIPTION
## Summary
- update collapsed nav item width/height to use sidebar width variables

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6841ab792860832e89f338282e722f11