### PR TITLE
Align icon sizes

### DIFF
--- a/src/features/dashboard/components/StatCards.tsx
+++ b/src/features/dashboard/components/StatCards.tsx
@@ -38,19 +38,19 @@ export const StatCards = () => {
       <StatCard
         title="Active Cases"
         value="0"
-        icon={<Briefcase className="h-4 w-4 text-muted-foreground" />}
+        icon={<Briefcase className="h-5 w-5 text-muted-foreground" />}
         description="Currently ongoing cases"
       />
       <StatCard
         title="Drafts"
         value="0"
-        icon={<FileEdit className="h-4 w-4 text-muted-foreground" />}
+        icon={<FileEdit className="h-5 w-5 text-muted-foreground" />}
         description="Cases saved as drafts"
       />
       <StatCard
         title="Completed Cases"
         value="0"
-        icon={<CheckCircle className="h-4 w-4 text-muted-foreground" />}
+        icon={<CheckCircle className="h-5 w-5 text-muted-foreground" />}
         description="Successfully closed cases"
       />
     </div>

--- a/src/features/navigation/components/Sidebar.tsx
+++ b/src/features/navigation/components/Sidebar.tsx
@@ -192,7 +192,7 @@ export const SidebarTrigger = () => {
       className="md:hidden"
       aria-label="Toggle sidebar"
     >
-      <Menu className="h-4 w-4" />
+      <Menu className="h-5 w-5" />
     </Button>
   );
 };
@@ -260,7 +260,7 @@ export const Sidebar = React.memo(function Sidebar() {
         data-active={location.pathname === item.href}
         ref={index === 0 ? firstLinkRef : undefined}
       >
-        <item.icon className="h-4 w-4" aria-hidden="true" />
+        <item.icon className="h-5 w-5" aria-hidden="true" />
         <span>{item.label}</span>
       </Link>
     </li>
@@ -278,7 +278,7 @@ export const Sidebar = React.memo(function Sidebar() {
               className="md:hidden"
               aria-label="Open sidebar"
             >
-              <Menu className="h-4 w-4" />
+              <Menu className="h-5 w-5" />
             </Button>
           </SheetTrigger>
           <SheetContent side="left" className="w-[var(--sidebar-width-mobile)]">
@@ -362,7 +362,7 @@ export const Sidebar = React.memo(function Sidebar() {
           {state === "expanded" && (
             <div className="p-4">
               <Button variant="outline" className="w-full" onClick={() => navigate("/cases/new")}>
-                <Plus className="mr-2 h-4 w-4" /> New Case
+                <Plus className="mr-2 h-5 w-5" /> New Case
               </Button>
             </div>
           )}


### PR DESCRIPTION
## Summary
- use 20px icons consistently in sidebar
- match stat card icons to 20px

## Testing
- `npm run test`
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841ad6c7514832e984a18bad2add732