### PR TITLE
Fix dashboard alignment

### DIFF
--- a/src/features/navigation/components/AppLayout.tsx
+++ b/src/features/navigation/components/AppLayout.tsx
@@ -33,8 +33,8 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children, className }) => 
           <h1 className="text-lg font-semibold">MedCase</h1>
           <div className="w-8" />
         </div>
-        <div className="flex-1 flex justify-center">
-          <div className="w-full max-w-6xl p-6">
+        <div className="flex-1 flex">
+          <div className="w-full max-w-6xl p-4">
             {children}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- remove center justification from main content so cards align with sidebar
- decrease page padding for better vertical alignment

## Testing
- `npm run lint --max-warnings=0` *(fails: Unexpected any and other lint errors)*
- `npm run build --if-present`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6841ad918e9c832e87e21f99d3a29f5d