### PR TITLE
Unify lucide icon sizes

### DIFF
--- a/src/constants/ui.ts
+++ b/src/constants/ui.ts
@@ -1,0 +1,2 @@
+export const ICON_SIZE = "h-5 w-5" as const;
+

--- a/src/features/dashboard/components/QuickStartPanel.tsx
+++ b/src/features/dashboard/components/QuickStartPanel.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Plus, BookOpen, Users, Settings } from "lucide-react";
+import { ICON_SIZE } from "@/constants/ui";
 import { useNavigate } from "react-router-dom";
 
 const quickActions = [
@@ -56,7 +57,7 @@ export const QuickStartPanel = () => {
                 onClick={() => navigate(action.action)}
               >
                 <div className="flex items-start space-x-3">
-                  <IconComponent className="h-5 w-5 mt-0.5 flex-shrink-0" />
+                  <IconComponent className={`${ICON_SIZE} mt-0.5 flex-shrink-0`} />
                   <div className="text-left">
                     <div className="font-medium">{action.title}</div>
                     <div className="text-sm text-muted-foreground mt-1">

--- a/src/features/dashboard/components/SearchPanel.tsx
+++ b/src/features/dashboard/components/SearchPanel.tsx
@@ -1,12 +1,13 @@
 import { Input } from "@/components/ui/input";
 import { Search } from "lucide-react";
+import { ICON_SIZE } from "@/constants/ui";
 import React from "react";
 
 export const SearchPanel = () => {
   return (
     <div className="relative w-full">
       <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-        <Search className="h-5 w-5 text-muted-foreground" />
+        <Search className={`${ICON_SIZE} text-muted-foreground`} />
       </div>
       <Input
         type="search"

--- a/src/features/dashboard/components/StatCards.tsx
+++ b/src/features/dashboard/components/StatCards.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Briefcase, CheckCircle, FileEdit } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { ICON_SIZE } from "@/constants/ui";
 import React from "react";
 
 interface StatCardProps {
@@ -38,19 +39,19 @@ export const StatCards = () => {
       <StatCard
         title="Active Cases"
         value="0"
-        icon={<Briefcase className="h-5 w-5 text-muted-foreground" />}
+        icon={<Briefcase className={`${ICON_SIZE} text-muted-foreground`} />}
         description="Currently ongoing cases"
       />
       <StatCard
         title="Drafts"
         value="0"
-        icon={<FileEdit className="h-5 w-5 text-muted-foreground" />}
+        icon={<FileEdit className={`${ICON_SIZE} text-muted-foreground`} />}
         description="Cases saved as drafts"
       />
       <StatCard
         title="Completed Cases"
         value="0"
-        icon={<CheckCircle className="h-5 w-5 text-muted-foreground" />}
+        icon={<CheckCircle className={`${ICON_SIZE} text-muted-foreground`} />}
         description="Successfully closed cases"
       />
     </div>

--- a/src/features/navigation/components/Sidebar.tsx
+++ b/src/features/navigation/components/Sidebar.tsx
@@ -43,6 +43,7 @@ import {
   ChevronDown,
 } from "lucide-react";
 import { cn } from "@/shared/utils";
+import { ICON_SIZE } from "@/constants/ui";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/app/AuthContext";
@@ -192,7 +193,7 @@ export const SidebarTrigger = () => {
       className="md:hidden"
       aria-label="Toggle sidebar"
     >
-      <Menu className="h-5 w-5" />
+      <Menu className={ICON_SIZE} />
     </Button>
   );
 };
@@ -245,7 +246,7 @@ export const Sidebar = React.memo(function Sidebar() {
           aria-label={item.label}
           ref={index === 0 ? firstLinkRef : undefined}
         >
-          <item.icon className="h-5 w-5" aria-hidden="true" />
+          <item.icon className={ICON_SIZE} aria-hidden="true" />
         </Link>
       </TooltipTrigger>
       <TooltipContent side="right">{item.label}</TooltipContent>
@@ -260,7 +261,7 @@ export const Sidebar = React.memo(function Sidebar() {
         data-active={location.pathname === item.href}
         ref={index === 0 ? firstLinkRef : undefined}
       >
-        <item.icon className="h-5 w-5" aria-hidden="true" />
+        <item.icon className={ICON_SIZE} aria-hidden="true" />
         <span>{item.label}</span>
       </Link>
     </li>
@@ -278,7 +279,7 @@ export const Sidebar = React.memo(function Sidebar() {
               className="md:hidden"
               aria-label="Open sidebar"
             >
-              <Menu className="h-5 w-5" />
+              <Menu className={ICON_SIZE} />
             </Button>
           </SheetTrigger>
           <SheetContent side="left" className="w-[var(--sidebar-width-mobile)]">
@@ -343,7 +344,7 @@ export const Sidebar = React.memo(function Sidebar() {
             )}
             <div className="flex items-center gap-2">
               <Button variant="ghost" size="icon" aria-label="Notifications">
-                <Bell className="h-5 w-5" />
+                <Bell className={ICON_SIZE} />
               </Button>
             </div>
           </div>
@@ -362,7 +363,7 @@ export const Sidebar = React.memo(function Sidebar() {
           {state === "expanded" && (
             <div className="p-4">
               <Button variant="outline" className="w-full" onClick={() => navigate("/cases/new")}>
-                <Plus className="mr-2 h-5 w-5" /> New Case
+                <Plus className={cn("mr-2", ICON_SIZE)} /> New Case
               </Button>
             </div>
           )}


### PR DESCRIPTION
## Summary
- add `ICON_SIZE` constant
- keep sidebar nav icons consistent
- make dashboard icons reference the shared constant

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_6841b1571890832ebfe2d36a24905b18