### PR TITLE
Refine dashboard text hierarchy

### DIFF
--- a/src/features/dashboard/components/QuickStartPanel.tsx
+++ b/src/features/dashboard/components/QuickStartPanel.tsx
@@ -59,7 +59,7 @@ export const QuickStartPanel = () => {
                   <IconComponent className="h-5 w-5 mt-0.5 flex-shrink-0" />
                   <div className="text-left">
                     <div className="font-medium">{action.title}</div>
-                    <div className="text-sm text-muted-foreground mt-1">
+                    <div className="text-sm font-medium text-muted-foreground mt-1">
                       {action.description}
                     </div>
                   </div>

--- a/src/features/dashboard/components/RecentActivityList.tsx
+++ b/src/features/dashboard/components/RecentActivityList.tsx
@@ -25,7 +25,7 @@ export const RecentActivityList = () => {
                   <p className="text-sm font-medium text-foreground truncate">
                     {item.description}
                   </p>
-                  <p className="text-xs text-muted-foreground">{item.time}</p>
+                  <p className="text-sm text-muted-foreground">{item.time}</p>
                 </div>
               </li>
             ))}


### PR DESCRIPTION
## Summary
- tighten typography on dashboard quick actions and activity list
- promote quick action descriptions to `font-medium`
- enlarge activity timestamps to match other secondary text

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_6841b157e794832eae224a11a44c3906