### PR TITLE
Refactor: centralize cn helper

### DIFF
--- a/src/features/navigation/components/AppLayout.tsx
+++ b/src/features/navigation/components/AppLayout.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Sidebar, SidebarTrigger, useSidebar } from "@/features/navigation";
-import { cn } from "@/shared/utils";
+import { cn } from "@/lib/utils";
 
 interface AppLayoutProps {
   children: React.ReactNode;

--- a/src/features/navigation/components/Sidebar.tsx
+++ b/src/features/navigation/components/Sidebar.tsx
@@ -42,7 +42,7 @@ import {
   LogOut,
   ChevronDown,
 } from "lucide-react";
-import { cn } from "@/shared/utils";
+import { cn } from "@/lib/utils";
 import { ICON_SIZE } from "@/constants/ui";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";

--- a/src/shared/ui/badge.tsx
+++ b/src/shared/ui/badge.tsx
@@ -2,7 +2,7 @@
 import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 
-import { cn } from "@/shared/utils"
+import { cn } from "@/lib/utils"
 
 const badgeVariants = cva(
   "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",

--- a/src/shared/ui/button.tsx
+++ b/src/shared/ui/button.tsx
@@ -3,7 +3,7 @@ import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
 
-import { cn } from "@/shared/utils"
+import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",

--- a/src/shared/ui/card.tsx
+++ b/src/shared/ui/card.tsx
@@ -1,7 +1,7 @@
 
 import * as React from "react"
 
-import { cn } from "@/shared/utils"
+import { cn } from "@/lib/utils"
 
 const Card = React.forwardRef<
   HTMLDivElement,

--- a/src/shared/ui/input.tsx
+++ b/src/shared/ui/input.tsx
@@ -1,7 +1,7 @@
 
 import * as React from "react"
 
-import { cn } from "@/shared/utils"
+import { cn } from "@/lib/utils"
 
 export interface InputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {}

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -1,7 +1,0 @@
-
-import { type ClassValue, clsx } from "clsx"
-import { twMerge } from "tailwind-merge"
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
-}


### PR DESCRIPTION
## Summary
- unify `cn` utility under `src/lib` and update imports
- remove duplicate helper from `src/shared`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841bc42f394832ebfa8be04d6441cc6