### PR TITLE
Wrap preset handler with useCallback

### DIFF
--- a/src/features/cases/InteractiveVitalsCard.tsx
+++ b/src/features/cases/InteractiveVitalsCard.tsx
@@ -327,16 +327,16 @@ export function InteractiveVitalsCard({
   ]);
 
   // Apply preset vital signs
-  const applyPreset = (preset: keyof typeof VITAL_PRESETS) => {
+  const applyPreset = useCallback((preset: keyof typeof VITAL_PRESETS) => {
     const presetValues = VITAL_PRESETS[preset];
-    
+
     setVitalSigns(prev => {
       return prev.map(vital => ({
         ...vital,
         value: presetValues[vital.name as keyof typeof presetValues] || vital.value
       }));
     });
-  };
+  }, []);
 
   // Memoize the handleVitalChange function to prevent unnecessary re-renders
   const handleVitalChange = useCallback((index: number, values: number[]) => {


### PR DESCRIPTION
## Summary
- memoize preset selection handler using `useCallback`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841bc625118832eb17a728b038321ed