### PR TITLE
Add InteractiveVitalsCard tests

### DIFF
--- a/src/features/cases/__tests__/InteractiveVitalsCard.test.tsx
+++ b/src/features/cases/__tests__/InteractiveVitalsCard.test.tsx
@@ -1,0 +1,54 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { describe, it, expect, afterEach, vi, beforeAll } from 'vitest';
+import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
+expect.extend(jestDomMatchers);
+
+import { InteractiveVitalsCard } from '../InteractiveVitalsCard';
+
+beforeAll(() => {
+  class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  // @ts-ignore
+  global.ResizeObserver = ResizeObserver;
+});
+
+
+describe('InteractiveVitalsCard', () => {
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it('calls onVitalsChange with updated values when a slider changes', () => {
+    vi.useFakeTimers();
+    const handleChange = vi.fn();
+    render(<InteractiveVitalsCard onVitalsChange={handleChange} />);
+
+    const sliders = screen.getAllByRole('slider');
+    const heartSlider = sliders[1];
+    heartSlider.focus();
+    fireEvent.keyDown(heartSlider, { key: 'ArrowUp' });
+
+    vi.advanceTimersByTime(150);
+
+    expect(handleChange).toHaveBeenCalled();
+    const lastCall = handleChange.mock.calls[handleChange.mock.calls.length - 1][0];
+    expect(lastCall.heartRate).toBe('81');
+    expect(heartSlider).toHaveAttribute('aria-valuenow', '81');
+  });
+
+  it('updates slider values when a preset button is clicked', () => {
+    render(<InteractiveVitalsCard onVitalsChange={() => {}} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /fever/i }));
+
+    const sliders = screen.getAllByRole('slider');
+    expect(sliders[0]).toHaveAttribute('aria-valuenow', '39.5');
+    expect(sliders[1]).toHaveAttribute('aria-valuenow', '110');
+  });
+});


### PR DESCRIPTION
## Summary
- add InteractiveVitalsCard unit tests verifying slider changes and preset button actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841bc63fa20832ebaebedfd494712d0