### PR TITLE
Share system symptoms data

### DIFF
--- a/src/features/cases/SymptomChecklist.tsx
+++ b/src/features/cases/SymptomChecklist.tsx
@@ -20,6 +20,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { systemSymptoms } from "./systemSymptoms";
 
 interface SymptomChecklistProps {
   onSelectionChange: (selections: Record<string, string[]>) => void;
@@ -30,105 +31,6 @@ interface SymptomChecklistProps {
   initialSymptoms?: Record<string, boolean>;
 }
 
-interface SystemSymptoms {
-  system: string;
-  symptoms: string[];
-}
-
-const systemSymptoms: SystemSymptoms[] = [
-  {
-    system: "Cardiovascular",
-    symptoms: [
-      "Chest pain",
-      "Palpitations",
-      "Shortness of breath",
-      "Edema",
-      "Orthopnea",
-      "Syncope",
-      "Claudication",
-      "Cyanosis",
-      "Hypertension",
-      "Hypotension",
-    ],
-  },
-  {
-    system: "Gastrointestinal",
-    symptoms: [
-      "Abdominal pain",
-      "Nausea",
-      "Vomiting",
-      "Diarrhea",
-      "Constipation",
-      "Heartburn",
-      "Dysphagia",
-      "Hematemesis",
-      "Melena",
-      "Jaundice",
-    ],
-  },
-  {
-    system: "Musculoskeletal",
-    symptoms: [
-      "Joint pain",
-      "Muscle pain",
-      "Swelling",
-      "Stiffness",
-      "Limited range of motion",
-      "Weakness",
-      "Back pain",
-      "Fractures",
-      "Redness",
-      "Deformity",
-    ],
-  },
-  {
-    system: "Neurological",
-    symptoms: [
-      "Headache",
-      "Dizziness",
-      "Seizures",
-      "Paresthesia",
-      "Weakness",
-      "Vision changes",
-      "Speech changes",
-      "Altered mental status",
-      "Tremor",
-      "Ataxia",
-    ],
-  },
-  {
-    system: "Respiratory",
-    symptoms: [
-      "Cough",
-      "Dyspnea",
-      "Wheezing",
-      "Hemoptysis",
-      "Sputum production",
-      "Pleuritic pain",
-      "Orthopnea",
-      "Stridor",
-      "Apnea",
-      "Tachypnea",
-    ],
-  },
-  {
-    system: "Urinary",
-    symptoms: [
-      "Dysuria",
-      "Frequency",
-      "Urgency",
-      "Hesitancy",
-      "Nocturia",
-      "Hematuria",
-      "Incontinence",
-      "Polyuria",
-      "Oliguria",
-      "Flank pain",
-      "Suprapubic pain",
-      "Urinary retention"
-    ],
-  }
-];
 
 // Memoized symptom item to prevent unnecessary re-renders
 const SymptomItem = memo(({

--- a/src/features/cases/SystemReviewChecklist.tsx
+++ b/src/features/cases/SystemReviewChecklist.tsx
@@ -5,64 +5,13 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { ChevronDown, ChevronRight } from "lucide-react";
+import { systemSymptoms } from "./systemSymptoms";
 
 interface SystemReviewChecklistProps {
   onSystemSymptomsChange?: (systemSymptoms: Record<string, string[]>) => void;
   initialSystemSymptoms?: Record<string, string[]>;
 }
 
-const SYSTEM_SYMPTOMS = {
-  "Cardiovascular": [
-    "Chest pain",
-    "Palpitations", 
-    "Shortness of breath",
-    "Edema",
-    "Syncope",
-    "Claudication"
-  ],
-  "Gastrointestinal": [
-    "Nausea",
-    "Vomiting",
-    "Abdominal pain",
-    "Diarrhea",
-    "Constipation",
-    "Heartburn",
-    "Blood in stool"
-  ],
-  "Musculoskeletal": [
-    "Joint pain",
-    "Muscle pain",
-    "Stiffness",
-    "Weakness",
-    "Back pain",
-    "Swelling"
-  ],
-  "Neurological": [
-    "Headache",
-    "Dizziness",
-    "Seizures",
-    "Memory problems",
-    "Numbness",
-    "Tingling",
-    "Vision changes"
-  ],
-  "Respiratory": [
-    "Cough",
-    "Shortness of breath",
-    "Wheezing",
-    "Chest tightness",
-    "Sputum production",
-    "Hemoptysis"
-  ],
-  "Urinary": [
-    "Dysuria",
-    "Frequency",
-    "Urgency",
-    "Hematuria",
-    "Incontinence",
-    "Retention"
-  ]
-};
 
 export function SystemReviewChecklist({ onSystemSymptomsChange, initialSystemSymptoms = {} }: SystemReviewChecklistProps) {
   const [selectedSymptoms, setSelectedSymptoms] = useState<Record<string, string[]>>(initialSystemSymptoms);
@@ -106,7 +55,7 @@ export function SystemReviewChecklist({ onSystemSymptomsChange, initialSystemSym
         <CardTitle>System Review & Symptoms</CardTitle>
       </CardHeader>
       <CardContent className="space-y-3">
-        {Object.entries(SYSTEM_SYMPTOMS).map(([system, symptoms]) => (
+        {systemSymptoms.map(({ system, symptoms }) => (
           <Collapsible
             key={system}
             open={expandedSystems[system]}

--- a/src/features/cases/systemSymptoms.ts
+++ b/src/features/cases/systemSymptoms.ts
@@ -1,0 +1,99 @@
+export interface SystemSymptoms {
+  system: string;
+  symptoms: string[];
+}
+
+export const systemSymptoms: SystemSymptoms[] = [
+  {
+    system: "Cardiovascular",
+    symptoms: [
+      "Chest pain",
+      "Palpitations",
+      "Shortness of breath",
+      "Edema",
+      "Orthopnea",
+      "Syncope",
+      "Claudication",
+      "Cyanosis",
+      "Hypertension",
+      "Hypotension",
+    ],
+  },
+  {
+    system: "Gastrointestinal",
+    symptoms: [
+      "Abdominal pain",
+      "Nausea",
+      "Vomiting",
+      "Diarrhea",
+      "Constipation",
+      "Heartburn",
+      "Dysphagia",
+      "Hematemesis",
+      "Melena",
+      "Jaundice",
+    ],
+  },
+  {
+    system: "Musculoskeletal",
+    symptoms: [
+      "Joint pain",
+      "Muscle pain",
+      "Swelling",
+      "Stiffness",
+      "Limited range of motion",
+      "Weakness",
+      "Back pain",
+      "Fractures",
+      "Redness",
+      "Deformity",
+    ],
+  },
+  {
+    system: "Neurological",
+    symptoms: [
+      "Headache",
+      "Dizziness",
+      "Seizures",
+      "Paresthesia",
+      "Weakness",
+      "Vision changes",
+      "Speech changes",
+      "Altered mental status",
+      "Tremor",
+      "Ataxia",
+    ],
+  },
+  {
+    system: "Respiratory",
+    symptoms: [
+      "Cough",
+      "Dyspnea",
+      "Wheezing",
+      "Hemoptysis",
+      "Sputum production",
+      "Pleuritic pain",
+      "Orthopnea",
+      "Stridor",
+      "Apnea",
+      "Tachypnea",
+    ],
+  },
+  {
+    system: "Urinary",
+    symptoms: [
+      "Dysuria",
+      "Frequency",
+      "Urgency",
+      "Hesitancy",
+      "Nocturia",
+      "Hematuria",
+      "Incontinence",
+      "Polyuria",
+      "Oliguria",
+      "Flank pain",
+      "Suprapubic pain",
+      "Urinary retention"
+    ],
+  }
+];


### PR DESCRIPTION
## Summary
- centralize system symptoms data in new `systemSymptoms.ts`
- use shared data in `SymptomChecklist` and `SystemReviewChecklist`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841bc709354832e99a48691a91a4b7c