### PR TITLE
Update SystemReviewChecklist state sync

### DIFF
--- a/src/features/cases/SystemReviewChecklist.tsx
+++ b/src/features/cases/SystemReviewChecklist.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
@@ -67,6 +67,10 @@ const SYSTEM_SYMPTOMS = {
 export function SystemReviewChecklist({ onSystemSymptomsChange, initialSystemSymptoms = {} }: SystemReviewChecklistProps) {
   const [selectedSymptoms, setSelectedSymptoms] = useState<Record<string, string[]>>(initialSystemSymptoms);
   const [expandedSystems, setExpandedSystems] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    setSelectedSymptoms(initialSystemSymptoms);
+  }, [initialSystemSymptoms]);
 
   const handleSymptomChange = (system: string, symptom: string, checked: boolean) => {
     const updatedSymptoms = { ...selectedSymptoms };

--- a/src/features/cases/__tests__/SystemReviewChecklist.test.tsx
+++ b/src/features/cases/__tests__/SystemReviewChecklist.test.tsx
@@ -1,0 +1,34 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
+expect.extend(jestDomMatchers);
+
+import { SystemReviewChecklist } from '../SystemReviewChecklist';
+
+
+describe('SystemReviewChecklist', () => {
+  it('updates selected symptoms when props change', () => {
+    const { rerender } = render(
+      <SystemReviewChecklist initialSystemSymptoms={{ Cardiovascular: ['Chest pain'] }} />
+    );
+
+    // Expand Cardiovascular system
+    fireEvent.click(screen.getByRole('button', { name: /Cardiovascular/i }));
+
+    // Initial checkbox should be checked
+    const chestPain = screen.getByLabelText('Chest pain');
+    expect(chestPain).toBeChecked();
+
+    // Rerender with new symptoms
+    rerender(
+      <SystemReviewChecklist initialSystemSymptoms={{ Cardiovascular: ['Edema'] }} />
+    );
+
+    // Edema should now be checked and Chest pain unchecked
+    const edema = screen.getByLabelText('Edema');
+    expect(edema).toBeChecked();
+    expect(chestPain).not.toBeChecked();
+  });
+});


### PR DESCRIPTION
## Summary
- synchronize `SystemReviewChecklist` with new props
- add a regression test to ensure prop changes update selected checkboxes

## Testing
- `npx vitest run --silent`

------
https://chatgpt.com/codex/tasks/task_e_6841bc720a10832ea00bf5dff0def0fa