### PR TITLE
Fix mobile header semantics

### DIFF
--- a/src/features/navigation/components/AppLayout.tsx
+++ b/src/features/navigation/components/AppLayout.tsx
@@ -28,11 +28,15 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children, className }) => 
           className
         )}
       >
-        <div className="flex items-center justify-between p-4 md:hidden border-b">
+        <header
+          className="flex items-center justify-between p-4 md:hidden border-b"
+          role="banner"
+          aria-label="Site"
+        >
           <SidebarTrigger />
           <h1 className="text-lg font-semibold">MedCase</h1>
           <div className="w-8" />
-        </div>
+        </header>
         <div className="flex-1 flex">
           <div className="w-full max-w-6xl p-4">
             {children}


### PR DESCRIPTION
## Summary
- wrap the mobile navigation bar in a `<header>` element
- add `role="banner"` and `aria-label="Site"`

## Testing
- `npm run lint` *(fails: 24 errors, 22 warnings)*
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6841bc845148832ea317ff7e0e3589bf