### PR TITLE
Fix mobile header alignment

### DIFF
--- a/src/features/navigation/components/AppLayout.tsx
+++ b/src/features/navigation/components/AppLayout.tsx
@@ -28,10 +28,9 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children, className }) => 
           className
         )}
       >
-        <div className="flex items-center justify-between p-4 md:hidden border-b">
+        <div className="flex items-center p-4 md:hidden border-b">
           <SidebarTrigger />
-          <h1 className="text-lg font-semibold">MedCase</h1>
-          <div className="w-8" />
+          <h1 className="flex-1 text-center text-lg font-semibold">MedCase</h1>
         </div>
         <div className="flex-1 flex">
           <div className="w-full max-w-6xl p-4">


### PR DESCRIPTION
## Summary
- remove placeholder div in AppLayout mobile header
- center heading using `flex-1 text-center`
- run Vitest suite

## Testing
- `./node_modules/.bin/vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6841bc84e9e4832eaa38ae5a97469a9b