### PR TITLE
Add settings page with theme and profile

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -14,6 +14,7 @@ import Cases from "@/pages/Cases";
 import CaseDetail from "@/pages/CaseDetail";
 import CaseEdit from "@/pages/CaseEdit";
 import CreateCaseFlow from "../pages/CreateCaseFlow";
+import Settings from "@/pages/Settings";
 import Auth from "@/pages/Auth";
 import NotFound from "@/pages/NotFound";
 import { PrivateRoute } from "@/features/auth/PrivateRoute";
@@ -115,15 +116,25 @@ const App = () => {
                         </PrivateRoute>
                       } 
                     />
-                    <Route 
-                      path="/cases/:id" 
+                    <Route
+                      path="/cases/:id"
                       element={
                         <PrivateRoute>
                           <AppLayout>
                             <CaseDetail />
                           </AppLayout>
                         </PrivateRoute>
-                      } 
+                      }
+                    />
+                    <Route
+                      path="/settings"
+                      element={
+                        <PrivateRoute>
+                          <AppLayout>
+                            <Settings />
+                          </AppLayout>
+                        </PrivateRoute>
+                      }
                     />
                     <Route path="*" element={<NotFound />} />
                   </Routes>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,0 +1,162 @@
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { useAuth } from "@/app/AuthContext";
+import { useTheme } from "@/app/ThemeContext";
+import { PageHeader } from "@/components/ui/page-header";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { SPECIALTIES } from "@/types/case";
+import { toast } from "sonner";
+
+const profileSchema = z.object({
+  full_name: z.string().min(1, "Full name is required"),
+  specialty: z.string().optional(),
+});
+
+type ProfileFormData = z.infer<typeof profileSchema>;
+
+const Settings = () => {
+  const { user, updateProfile } = useAuth();
+  const { theme, setTheme } = useTheme();
+
+  const form = useForm<ProfileFormData>({
+    resolver: zodResolver(profileSchema),
+    defaultValues: {
+      full_name: "",
+      specialty: "",
+    },
+  });
+
+  useEffect(() => {
+    form.reset({
+      full_name: (user?.user_metadata as any)?.full_name || "",
+      specialty: (user?.user_metadata as any)?.specialty || "",
+    });
+  }, [user]);
+
+  const onSubmit = async (data: ProfileFormData) => {
+    try {
+      await updateProfile({
+        full_name: data.full_name,
+        specialty: data.specialty,
+      });
+      toast.success("Profile updated");
+    } catch (error: any) {
+      toast.error(error.message || "Failed to update profile");
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Settings"
+        description="Manage your account and preferences"
+      />
+      <div className="grid gap-6 md:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>Profile</CardTitle>
+            <CardDescription>Update your personal information</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Form {...form}>
+              <form
+                onSubmit={form.handleSubmit(onSubmit)}
+                className="space-y-4"
+              >
+                <FormField
+                  control={form.control}
+                  name="full_name"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Full Name</FormLabel>
+                      <FormControl>
+                        <Input placeholder="Your name" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="specialty"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Specialty</FormLabel>
+                      <FormControl>
+                        <Select
+                          defaultValue={field.value}
+                          onValueChange={field.onChange}
+                        >
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select specialty" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="">None</SelectItem>
+                            {SPECIALTIES.map((s) => (
+                              <SelectItem key={s.id} value={s.id}>
+                                {s.name}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <Button type="submit">Save Changes</Button>
+              </form>
+            </Form>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Preferences</CardTitle>
+            <CardDescription>Customize application behavior</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm font-medium">Dark Mode</p>
+              </div>
+              <Switch
+                checked={theme === "dark"}
+                onCheckedChange={(checked) =>
+                  setTheme(checked ? "dark" : "light")
+                }
+              />
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default Settings;


### PR DESCRIPTION
## Summary
- create new **Settings** page for profile updates and theme toggle
- wire `/settings` route into application

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d00fe688832eb37019a183670138