### PR TITLE
Update sidebar state usage in UserProfileDisplay

### DIFF
--- a/src/features/auth/UserProfileDisplay.tsx
+++ b/src/features/auth/UserProfileDisplay.tsx
@@ -12,7 +12,8 @@ import {
 
 export function UserProfileDisplay() {
   const { user, signOut } = useAuth();
-  const { open, isMobile } = useSidebar();
+  const { state, isMobile } = useSidebar();
+  const open = state === "expanded";
   
   if (!user) {
     return null;


### PR DESCRIPTION
## Summary
- use `state` from `useSidebar` to derive `open` value in `UserProfileDisplay`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d0743ab8832e93fa11471fea7a77