### PR TITLE
Redesign sidebar

### DIFF
--- a/src/features/navigation/__tests__/Sidebar.test.tsx
+++ b/src/features/navigation/__tests__/Sidebar.test.tsx
@@ -15,8 +15,8 @@ import * as sidebarUtils from '@/constants/sidebar';
 const { SIDEBAR_CONFIG, getInitialSidebarState } = sidebarUtils;
 
 const SidebarStateDisplay = () => {
-  const { state } = useSidebar();
-  return <div data-testid="sidebar-state">{state}</div>;
+  const { open } = useSidebar();
+  return <div data-testid="sidebar-state">{open ? 'open' : 'closed'}</div>;
 };
 
 const renderWithProviders = (ui: React.ReactNode) =>

--- a/src/features/navigation/components/AppLayout.tsx
+++ b/src/features/navigation/components/AppLayout.tsx
@@ -8,14 +8,14 @@ interface AppLayoutProps {
 }
 
 export const AppLayout: React.FC<AppLayoutProps> = ({ children, className }) => {
-  const { state, isMobile } = useSidebar();
+  const { open, isMobile } = useSidebar();
 
   // Determine padding based on sidebar state and screen size
   const mainPaddingClass = isMobile
-    ? "pl-0" // No padding on mobile (sidebar is an overlay)
-    : state === "expanded"
-    ? "pl-[var(--sidebar-width)]" // Padding for expanded sidebar on desktop
-    : "pl-[var(--sidebar-width-icon)]"; // Padding for collapsed sidebar on desktop
+    ? "pl-0"
+    : open
+    ? "pl-[var(--sidebar-width)]"
+    : "pl-0";
 
   return (
     <div className="min-h-screen bg-background">

--- a/src/features/navigation/components/Sidebar.tsx
+++ b/src/features/navigation/components/Sidebar.tsx
@@ -1,118 +1,49 @@
-import React, {
-  useState,
-  useEffect,
-  useRef,
-  useContext,
-  createContext,
-  useCallback,
-  useMemo,
-} from "react";
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-  SheetTrigger,
-} from "@/components/ui/sheet";
-import {
-  NavigationMenu,
-  NavigationMenuContent,
-  NavigationMenuItem,
-  NavigationMenuLink,
-  NavigationMenuList,
-  NavigationMenuTrigger,
-  navigationMenuTriggerStyle,
-} from "@/components/ui/navigation-menu";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import {
-  Bell,
-  Menu,
-  Home,
-  Plus,
-  LayoutDashboard,
-  BookOpen,
-  Settings,
-  User,
-  HelpCircle,
-  LogOut,
-  ChevronDown,
-} from "lucide-react";
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { Link, useLocation } from "react-router-dom";
+import { Menu, X, LayoutDashboard, BookOpen, Settings } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { ICON_SIZE } from "@/constants/ui";
-import { Link, useLocation, useNavigate } from "react-router-dom";
-import { Button } from "@/components/ui/button";
-import { useAuth } from "@/app/AuthContext";
-import {
-  SIDEBAR_CONFIG,
-  saveSidebarState,
-  getInitialSidebarState,
-} from "@/constants/sidebar";
+import { SIDEBAR_CONFIG, getInitialSidebarState, saveSidebarState } from "@/constants/sidebar";
 
-type SidebarState = "expanded" | "collapsed";
-
-type SidebarContextValue = {
-  state: SidebarState;
+interface SidebarContextValue {
+  open: boolean;
   isMobile: boolean;
   toggle: () => void;
-  expand: () => void;
-  collapse: () => void;
-};
+  openSidebar: () => void;
+  closeSidebar: () => void;
+}
 
 const SidebarContext = createContext<SidebarContextValue>({
-  state: "collapsed",
+  open: false,
   isMobile: false,
   toggle: () => {},
-  expand: () => {},
-  collapse: () => {},
+  openSidebar: () => {},
+  closeSidebar: () => {},
 });
 
 interface SidebarProviderProps {
   children: React.ReactNode;
 }
 
-export const SidebarProvider: React.FC<SidebarProviderProps> = ({
-  children,
-}) => {
-  const [state, setState] = useState<SidebarState>(() =>
-    getInitialSidebarState(false) ? "expanded" : "collapsed"
-  );
+export const SidebarProvider: React.FC<SidebarProviderProps> = ({ children }) => {
+  const [open, setOpen] = useState(() => getInitialSidebarState(false));
   const [isMobile, setIsMobile] = useState(false);
-  const location = useLocation();
-  const firstLinkRef = useRef<HTMLAnchorElement>(null);
 
-  const toggle = useCallback(() => {
-    setState((prevState) => {
-      const next = prevState === "collapsed" ? "expanded" : "collapsed";
-      saveSidebarState(next === "expanded");
-      return next;
-    });
-  }, []);
-
-  const expand = useCallback(() => {
-    setState("expanded");
-    saveSidebarState(true);
-  }, []);
-
-  const collapse = useCallback(() => {
-    setState("collapsed");
-    saveSidebarState(false);
-  }, []);
+  const toggle = useCallback(() => setOpen((o) => !o), []);
+  const openSidebar = useCallback(() => setOpen(true), []);
+  const closeSidebar = useCallback(() => setOpen(false), []);
 
   useEffect(() => {
-    const handleResize = () => {
-      setIsMobile(window.innerWidth < 768);
-    };
+    saveSidebarState(open);
+  }, [open]);
 
+  useEffect(() => {
+    const handleResize = () => setIsMobile(window.innerWidth < 768);
     if (typeof window !== "undefined") {
       window.addEventListener("resize", handleResize);
       handleResize();
     }
-
     return () => {
       if (typeof window !== "undefined") {
         window.removeEventListener("resize", handleResize);
@@ -121,58 +52,31 @@ export const SidebarProvider: React.FC<SidebarProviderProps> = ({
   }, []);
 
   useEffect(() => {
-    if (state === "expanded") {
-      collapse();
-    }
-  }, [location.pathname, collapse, state]);
-
-  const value = useMemo(
-    () => ({
-      state,
-      isMobile,
-      toggle,
-      expand,
-      collapse,
-    }),
-    [state, isMobile, toggle, expand, collapse]
-  );
-
-  useEffect(() => {
-    saveSidebarState(state === "expanded");
-  }, [state]);
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const handleKeyDown = (event: KeyboardEvent) => {
+    const handleKey = (e: KeyboardEvent) => {
       if (
-        event.key.toLowerCase() === SIDEBAR_CONFIG.KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
+        e.key.toLowerCase() === SIDEBAR_CONFIG.KEYBOARD_SHORTCUT &&
+        (e.metaKey || e.ctrlKey)
       ) {
-        event.preventDefault();
+        e.preventDefault();
         toggle();
       }
     };
-
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
   }, [toggle]);
 
-  useEffect(() => {
-    if (isMobile && state === "expanded") {
-      firstLinkRef.current?.focus();
-    }
-  }, [isMobile, state]);
+  const value = useMemo(
+    () => ({ open, isMobile, toggle, openSidebar, closeSidebar }),
+    [open, isMobile, toggle, openSidebar, closeSidebar]
+  );
 
   return (
     <SidebarContext.Provider value={value}>
       <div
         style={{
-          "--sidebar-width": SIDEBAR_CONFIG.WIDTH,
-          "--sidebar-width-icon": SIDEBAR_CONFIG.WIDTH_ICON,
-          "--sidebar-width-mobile": SIDEBAR_CONFIG.WIDTH_MOBILE,
+          '--sidebar-width': SIDEBAR_CONFIG.WIDTH,
+          '--sidebar-width-mobile': SIDEBAR_CONFIG.WIDTH_MOBILE,
         } as React.CSSProperties}
-        className="group/sidebar-wrapper"
-        data-state={state}
       >
         {children}
       </div>
@@ -190,7 +94,6 @@ export const SidebarTrigger = () => {
       variant="ghost"
       size="sm"
       onClick={toggle}
-      className="md:hidden"
       aria-label="Toggle sidebar"
     >
       <Menu className={ICON_SIZE} />
@@ -199,177 +102,66 @@ export const SidebarTrigger = () => {
 };
 
 const navItems = [
-  {
-    href: "/dashboard",
-    label: "Dashboard",
-    icon: LayoutDashboard,
-  },
-  {
-    href: "/cases",
-    label: "Cases",
-    icon: BookOpen,
-  },
-  {
-    href: "/settings",
-    label: "Settings",
-    icon: Settings,
-  },
-  {
-    href: "/help",
-    label: "Help",
-    icon: HelpCircle,
-  },
+  { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
+  { href: "/cases", label: "Cases", icon: BookOpen },
+  { href: "/settings", label: "Settings", icon: Settings },
 ];
 
 export const Sidebar = React.memo(function Sidebar() {
-  const { state, isMobile, expand, collapse } = useSidebar();
-  const { user, signOut } = useAuth();
-  const navigate = useNavigate();
+  const { open, isMobile, closeSidebar } = useSidebar();
   const location = useLocation();
-  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-  const [hovered, setHovered] = useState(false);
-  const firstLinkRef = useRef<HTMLAnchorElement>(null);
 
-  const handleSignOut = async () => {
-    await signOut();
-    navigate("/auth");
-  };
-
-
-  const CollapsedNavItem = ({ item, index }: { item: (typeof navItems)[0]; index: number }) => (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Link
-          to={item.href}
-          className="group flex h-[var(--sidebar-width-icon)] w-[var(--sidebar-width-icon)] flex-col items-center justify-center rounded-md text-muted-foreground outline-none data-[active=true]:bg-accent data-[active=true]:text-accent-foreground"
-          data-active={location.pathname === item.href}
-          aria-label={item.label}
-          ref={index === 0 ? firstLinkRef : undefined}
-        >
-          <item.icon className={ICON_SIZE} aria-hidden="true" />
-        </Link>
-      </TooltipTrigger>
-      <TooltipContent side="right">{item.label}</TooltipContent>
-    </Tooltip>
-  );
-
-  const ExpandedNavItem = ({ item, index }: { item: (typeof navItems)[0]; index: number }) => (
-    <li className="mb-2">
-      <Link
-        to={item.href}
-        className="group flex items-center space-x-3 rounded-md p-2 text-sm font-medium text-muted-foreground hover:bg-accent hover:text-accent-foreground data-[active=true]:bg-accent data-[active=true]:text-accent-foreground"
-        data-active={location.pathname === item.href}
-        ref={index === 0 ? firstLinkRef : undefined}
-      >
-        <item.icon className={ICON_SIZE} aria-hidden="true" />
-        <span>{item.label}</span>
-      </Link>
-    </li>
-  );
-
-  return (
-    <>
-      {isMobile && (
-        <Sheet>
-          <SheetTrigger asChild>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="md:hidden"
-              aria-label="Open sidebar"
-            >
-              <Menu className={ICON_SIZE} />
-            </Button>
-          </SheetTrigger>
-          <SheetContent side="left" className="w-[var(--sidebar-width-mobile)]">
-            <SheetHeader className="text-left">
-              <SheetTitle>Navigation</SheetTitle>
-              <SheetDescription>
-                Navigate through the application.
-              </SheetDescription>
-            </SheetHeader>
-            <NavigationMenu>
-              <NavigationMenuList>
-                {navItems.map((item, index) => (
-                  <NavigationMenuItem key={item.href}>
-                    <NavigationMenuLink asChild>
-                      <Link
-                        to={item.href}
-                        ref={index === 0 ? firstLinkRef : undefined}
-                      >
-                        {item.label}
-                      </Link>
-                    </NavigationMenuLink>
-                  </NavigationMenuItem>
-                ))}
-              </NavigationMenuList>
-            </NavigationMenu>
-          </SheetContent>
-        </Sheet>
-      )}
-
-      <div
-        onMouseEnter={() => {
-          if (!isMobile && state === "collapsed") {
-            expand();
-            setHovered(true);
-          }
-        }}
-        onMouseLeave={() => {
-          if (!isMobile && hovered) {
-            collapse();
-            setHovered(false);
-          }
-        }}
-        className={cn(
-          "bg-background fixed left-0 top-0 z-50 flex h-screen flex-col border-r shadow-sm transition-all duration-300 ease-in-out",
-          state === "expanded" ? "w-[var(--sidebar-width)]" : "w-[var(--sidebar-width-icon)]",
-          isMobile ? "hidden" : "block"
-        )}
-        role="complementary"
-        aria-label="Sidebar navigation"
-        aria-expanded={state === "expanded"}
-      >
-        <div className="flex flex-col h-full">
-          <div className="flex items-center justify-between px-4 py-4">
-            {state === "expanded" ? (
-              <Link to="/" className="font-bold text-lg">
-                MedCase
-              </Link>
-            ) : (
-              <Link to="/" className="font-bold text-lg">
-                MC
-              </Link>
-            )}
-            <div className="flex items-center gap-2">
-              <Button variant="ghost" size="icon" aria-label="Notifications">
-                <Bell className={ICON_SIZE} />
-              </Button>
-            </div>
-          </div>
-
-          <div className="flex-1 overflow-y-auto px-4 py-4">
-            <ul className="space-y-2">
-              {navItems.map((item, index) =>
-                state === "expanded" ? (
-                  <ExpandedNavItem key={item.href} item={item} index={index} />
-                ) : (
-                  <CollapsedNavItem key={item.href} item={item} index={index} />
-                )
+  const content = (
+    <nav className="flex h-full flex-col p-4">
+      <ul className="space-y-2">
+        {navItems.map((item) => (
+          <li key={item.href}>
+            <Link
+              to={item.href}
+              className={cn(
+                "flex items-center space-x-2 rounded-md p-2 text-sm hover:bg-accent",
+                location.pathname === item.href &&
+                  "bg-accent text-accent-foreground"
               )}
-            </ul>
-          </div>
-          {state === "expanded" && (
-            <div className="px-4 py-4">
-              <Button variant="outline" className="w-full" onClick={() => navigate("/cases/new")}>
-                <Plus className={cn("mr-2", ICON_SIZE)} /> New Case
-              </Button>
-            </div>
-          )}
+            >
+              <item.icon className={ICON_SIZE} />
+              <span>{item.label}</span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+
+  if (isMobile) {
+    return (
+      <div className={cn("fixed inset-0 z-50 flex", open ? "visible" : "invisible")}>
+        <div className="absolute inset-0 bg-black/50" onClick={closeSidebar} />
+        <div className="relative h-full w-[var(--sidebar-width-mobile)] bg-background border-r shadow-lg">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="absolute right-2 top-2"
+            onClick={closeSidebar}
+            aria-label="Close sidebar"
+          >
+            <X className={ICON_SIZE} />
+          </Button>
+          {content}
         </div>
       </div>
-    </>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        "fixed inset-y-0 left-0 z-40 w-[var(--sidebar-width)] -translate-x-full bg-background border-r shadow-sm transition-transform duration-300",
+        open && "translate-x-0"
+      )}
+    >
+      {content}
+    </div>
   );
 });
 


### PR DESCRIPTION
## Summary
- rebuild sidebar with simpler open/close behaviour
- adjust AppLayout to use the new sidebar state
- update sidebar tests for the new context

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d0764790832eb4dd76c03b6df301