### PR TITLE
Implement delete logic for Cases page

### DIFF
--- a/src/features/cases/__tests__/CaseListItem.test.tsx
+++ b/src/features/cases/__tests__/CaseListItem.test.tsx
@@ -1,0 +1,41 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
+expect.extend(jestDomMatchers);
+
+import { CaseListItem } from '../CaseListItem';
+import { MedicalCase } from '@/types/case';
+
+const mockCase: MedicalCase = {
+  id: '1',
+  title: 'Test Case',
+  priority: 'medium',
+  patient: { id: 'p1', name: 'John Doe', age: 30, gender: 'male' },
+  chiefComplaint: 'Headache',
+  diagnoses: [],
+  tags: [],
+  resources: [],
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+describe('CaseListItem', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('calls onDelete when delete button is clicked', () => {
+    const onDelete = vi.fn();
+    render(
+      <BrowserRouter>
+        <CaseListItem medicalCase={mockCase} onDelete={onDelete} />
+      </BrowserRouter>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /delete case/i }));
+    expect(onDelete).toHaveBeenCalledWith(mockCase.id);
+  });
+});

--- a/src/lib/api/cases.ts
+++ b/src/lib/api/cases.ts
@@ -45,3 +45,14 @@ export const createCase = async (data: CreateCaseRequest): Promise<MedicalCase> 
 
   return newCase;
 };
+
+export const deleteCase = async (caseId: string): Promise<void> => {
+  // Placeholder for future API integration
+  console.log('Deleting case:', caseId);
+  if (typeof window !== 'undefined') {
+    const stored = JSON.parse(localStorage.getItem('cases') || '[]') as MedicalCase[];
+    const updated = stored.filter((c) => c.id !== caseId);
+    localStorage.setItem('cases', JSON.stringify(updated));
+  }
+}
+


### PR DESCRIPTION
## Summary
- support deleting cases on the Cases page with react-query
- add a mock `deleteCase` API helper
- show delete errors using `useErrorHandler`
- test that CaseListItem triggers the delete callback

## Testing
- `npx vitest run`
- `npm run lint` *(fails: Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6841d0754a2c832eafc37fb7ac36812e