### PR TITLE
Update sidebar hook usage

### DIFF
--- a/src/features/auth/UserProfileDisplay.tsx
+++ b/src/features/auth/UserProfileDisplay.tsx
@@ -12,8 +12,7 @@ import {
 
 export function UserProfileDisplay() {
   const { user, signOut } = useAuth();
-  const { state, isMobile } = useSidebar();
-  const open = state === "expanded";
+  const { open, isMobile } = useSidebar();
   
   if (!user) {
     return null;

--- a/src/features/navigation/components/Sidebar.tsx
+++ b/src/features/navigation/components/Sidebar.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { saveSidebarState, getInitialSidebarState } from "@/constants/sidebar";
 import { Menu, X, LayoutDashboard, BookOpen, Settings } from "lucide-react";
 
 interface SidebarContextValue {
@@ -25,22 +26,6 @@ const SIDEBAR_CONFIG = {
 
 const ICON_SIZE = "w-5 h-5";
 
-const getInitialSidebarState = (defaultState: boolean) => {
-  try {
-    const saved = localStorage.getItem('sidebarOpen');
-    return saved ? JSON.parse(saved) : defaultState;
-  } catch {
-    return defaultState;
-  }
-};
-
-const saveSidebarState = (state: boolean) => {
-  try {
-    localStorage.setItem('sidebarOpen', JSON.stringify(state));
-  } catch {
-    // Ignore errors
-  }
-};
 
 interface SidebarProviderProps {
   children: React.ReactNode;


### PR DESCRIPTION
## Summary
- update UserProfileDisplay to use `open` from `useSidebar`
- connect Sidebar provider to cookie helpers so tests observe state changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841f9c1b590832eb457cc84a3ebe5c6