### PR TITLE
Unified sidebar persistence

### DIFF
--- a/src/constants/sidebar.ts
+++ b/src/constants/sidebar.ts
@@ -1,6 +1,5 @@
 export const SIDEBAR_CONFIG = {
-  COOKIE_NAME: "sidebar:state",
-  COOKIE_MAX_AGE: 60 * 60 * 24 * 7,
+  STORAGE_KEY: "sidebar:state",
   WIDTH: "16rem",
   WIDTH_MOBILE: "18rem",
   WIDTH_ICON: "4rem",
@@ -9,15 +8,20 @@ export const SIDEBAR_CONFIG = {
 
 export const saveSidebarState = (state: boolean) => {
   try {
-    document.cookie = `${SIDEBAR_CONFIG.COOKIE_NAME}=${state}; path=/; max-age=${SIDEBAR_CONFIG.COOKIE_MAX_AGE}`;
+    if (typeof window !== "undefined") {
+      localStorage.setItem(SIDEBAR_CONFIG.STORAGE_KEY, JSON.stringify(state));
+    }
   } catch (error) {
     console.warn("Failed to save sidebar state:", error);
   }
 };
 
 export const getInitialSidebarState = (defaultOpen = false) => {
-  if (typeof document === "undefined") return defaultOpen;
-  const cookies = document.cookie.split(";");
-  const sidebarCookie = cookies.find((c) => c.trim().startsWith(SIDEBAR_CONFIG.COOKIE_NAME));
-  return sidebarCookie ? sidebarCookie.split("=")[1] === "true" : defaultOpen;
+  if (typeof window === "undefined") return defaultOpen;
+  try {
+    const stored = localStorage.getItem(SIDEBAR_CONFIG.STORAGE_KEY);
+    return stored !== null ? JSON.parse(stored) : defaultOpen;
+  } catch {
+    return defaultOpen;
+  }
 };

--- a/src/features/navigation/__tests__/Sidebar.test.tsx
+++ b/src/features/navigation/__tests__/Sidebar.test.tsx
@@ -26,20 +26,20 @@ const renderWithProviders = (ui: React.ReactNode) =>
     </BrowserRouter>
   );
 
-const clearSidebarCookie = () => {
-  document.cookie = `${SIDEBAR_CONFIG.COOKIE_NAME}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
+const clearSidebarStorage = () => {
+  localStorage.removeItem(SIDEBAR_CONFIG.STORAGE_KEY);
 };
 
 describe('Sidebar Provider', () => {
   afterEach(() => {
     cleanup();
-    clearSidebarCookie();
+    clearSidebarStorage();
   });
 
-  it('getInitialSidebarState reads open and closed values from cookies', () => {
-    document.cookie = `${SIDEBAR_CONFIG.COOKIE_NAME}=true`;
+  it('getInitialSidebarState reads open and closed values from localStorage', () => {
+    localStorage.setItem(SIDEBAR_CONFIG.STORAGE_KEY, 'true');
     expect(getInitialSidebarState(false)).toBe(true);
-    document.cookie = `${SIDEBAR_CONFIG.COOKIE_NAME}=false`;
+    localStorage.setItem(SIDEBAR_CONFIG.STORAGE_KEY, 'false');
     expect(getInitialSidebarState(true)).toBe(false);
   });
 

--- a/src/features/navigation/components/Sidebar.tsx
+++ b/src/features/navigation/components/Sidebar.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { Menu, X, LayoutDashboard, BookOpen, Settings } from "lucide-react";
+import { SIDEBAR_CONFIG, getInitialSidebarState, saveSidebarState } from "@/constants/sidebar";
 
 interface SidebarContextValue {
   open: boolean;
@@ -17,30 +18,7 @@ const SidebarContext = createContext<SidebarContextValue>({
   closeSidebar: () => {},
 });
 
-const SIDEBAR_CONFIG = {
-  WIDTH: '240px',
-  WIDTH_MOBILE: '280px',
-  KEYBOARD_SHORTCUT: 'b'
-};
-
 const ICON_SIZE = "w-5 h-5";
-
-const getInitialSidebarState = (defaultState: boolean) => {
-  try {
-    const saved = localStorage.getItem('sidebarOpen');
-    return saved ? JSON.parse(saved) : defaultState;
-  } catch {
-    return defaultState;
-  }
-};
-
-const saveSidebarState = (state: boolean) => {
-  try {
-    localStorage.setItem('sidebarOpen', JSON.stringify(state));
-  } catch {
-    // Ignore errors
-  }
-};
 
 interface SidebarProviderProps {
   children: React.ReactNode;


### PR DESCRIPTION
## Summary
- consolidate sidebar persistence utilities in `src/constants/sidebar.ts`
- switch sidebar state to use `localStorage`
- import updated helpers in `Sidebar` component
- adjust sidebar tests for the new persistence method

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841f9c7d008832eb44173ca574fa278