### PR TITLE
Switch sidebar links to NavLink

### DIFF
--- a/src/features/navigation/__tests__/Sidebar.test.tsx
+++ b/src/features/navigation/__tests__/Sidebar.test.tsx
@@ -1,7 +1,7 @@
 /** @vitest-environment jsdom */
 import React from 'react';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
-import { BrowserRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import * as jestDomMatchers from '@testing-library/jest-dom/matchers';
 expect.extend(jestDomMatchers);
@@ -10,7 +10,7 @@ vi.mock('@/app/AuthContext', () => ({
   useAuth: () => ({ user: null, signOut: vi.fn() }),
 }));
 
-import { SidebarProvider, SidebarTrigger, useSidebar } from '..';
+import { SidebarProvider, SidebarTrigger, useSidebar, Sidebar } from '..';
 import * as sidebarUtils from '@/constants/sidebar';
 const { SIDEBAR_CONFIG, getInitialSidebarState } = sidebarUtils;
 
@@ -19,21 +19,24 @@ const SidebarStateDisplay = () => {
   return <div data-testid="sidebar-state">{open ? 'open' : 'closed'}</div>;
 };
 
-const renderWithProviders = (ui: React.ReactNode) =>
+const renderWithProviders = (ui: React.ReactNode, initialPath = '/') =>
   render(
-    <BrowserRouter>
+    <MemoryRouter initialEntries={[initialPath]}>
       <SidebarProvider>{ui}</SidebarProvider>
-    </BrowserRouter>
+    </MemoryRouter>
   );
 
 const clearSidebarCookie = () => {
   document.cookie = `${SIDEBAR_CONFIG.COOKIE_NAME}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
+  localStorage.removeItem('sidebarOpen');
 };
 
 describe('Sidebar Provider', () => {
   afterEach(() => {
     cleanup();
     clearSidebarCookie();
+    window.innerWidth = 1024;
+    window.dispatchEvent(new Event('resize'));
   });
 
   it('getInitialSidebarState reads open and closed values from cookies', () => {
@@ -44,7 +47,6 @@ describe('Sidebar Provider', () => {
   });
 
   it('SidebarTrigger toggles state on desktop', () => {
-    const saveSpy = vi.spyOn(sidebarUtils, 'saveSidebarState').mockImplementation(() => {});
     window.innerWidth = 1024;
     renderWithProviders(
       <>
@@ -53,42 +55,57 @@ describe('Sidebar Provider', () => {
       </>
     );
     const btn = screen.getByRole('button', { name: /toggle sidebar/i });
+    // default open on desktop
+    expect(screen.getByTestId('sidebar-state')).toHaveTextContent('open');
     fireEvent.click(btn);
-    expect(saveSpy.mock.calls.some(([arg]) => arg === true)).toBe(true);
+    expect(screen.getByTestId('sidebar-state')).toHaveTextContent('closed');
     fireEvent.click(btn);
-    expect(saveSpy.mock.calls.some(([arg]) => arg === false)).toBe(true);
-    saveSpy.mockRestore();
+    expect(screen.getByTestId('sidebar-state')).toHaveTextContent('open');
   });
 
   it('SidebarTrigger toggles state on mobile', () => {
-    const saveSpy = vi.spyOn(sidebarUtils, 'saveSidebarState').mockImplementation(() => {});
     window.innerWidth = 375;
     window.dispatchEvent(new Event('resize'));
     renderWithProviders(
       <>
         <SidebarTrigger />
         <SidebarStateDisplay />
-      </>
+      </>,
+      '/'
     );
     const btn = screen.getByRole('button', { name: /toggle sidebar/i });
+    // default closed on mobile
+    expect(screen.getByTestId('sidebar-state')).toHaveTextContent('closed');
     fireEvent.click(btn);
-    expect(saveSpy.mock.calls.some(([arg]) => arg === true)).toBe(true);
-    saveSpy.mockRestore();
+    expect(screen.getByTestId('sidebar-state')).toHaveTextContent('open');
   });
 
   it('keyboard shortcut toggles the sidebar', () => {
-    const saveSpy = vi.spyOn(sidebarUtils, 'saveSidebarState').mockImplementation(() => {});
     renderWithProviders(<SidebarStateDisplay />);
+    expect(screen.getByTestId('sidebar-state')).toHaveTextContent('open');
     fireEvent.keyDown(window, {
       key: SIDEBAR_CONFIG.KEYBOARD_SHORTCUT,
       ctrlKey: true,
     });
-    expect(saveSpy.mock.calls.some(([arg]) => arg === true)).toBe(true);
+    expect(screen.getByTestId('sidebar-state')).toHaveTextContent('closed');
     fireEvent.keyDown(window, {
       key: SIDEBAR_CONFIG.KEYBOARD_SHORTCUT,
       ctrlKey: true,
     });
-    expect(saveSpy.mock.calls.some(([arg]) => arg === false)).toBe(true);
-    saveSpy.mockRestore();
+    expect(screen.getByTestId('sidebar-state')).toHaveTextContent('open');
+  });
+
+  it('navigation does not reload the page and highlights active link', () => {
+    renderWithProviders(<Sidebar />, '/dashboard');
+    const nav = screen.getByRole('navigation');
+    const dashboardLink = screen.getByRole('link', { name: /dashboard/i });
+    const casesLink = screen.getByRole('link', { name: /cases/i });
+    expect(dashboardLink).toHaveClass('bg-gray-100');
+    expect(casesLink).not.toHaveClass('bg-gray-100');
+    fireEvent.click(casesLink);
+    expect(nav).toBeInTheDocument();
+    expect(casesLink).toHaveAttribute('aria-current', 'page');
+    expect(casesLink).toHaveClass('bg-gray-100');
+    expect(dashboardLink).not.toHaveClass('bg-gray-100');
   });
 });

--- a/src/features/navigation/components/Sidebar.tsx
+++ b/src/features/navigation/components/Sidebar.tsx
@@ -1,5 +1,7 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { Menu, X, LayoutDashboard, BookOpen, Settings } from "lucide-react";
+import { NavLink } from 'react-router-dom';
+import { cn } from '@/lib/utils';
 
 interface SidebarContextValue {
   open: boolean;
@@ -130,21 +132,24 @@ const navItems = [
 
 const Sidebar = React.memo(function Sidebar() {
   const { open, isMobile, closeSidebar } = useSidebar();
-  const location = { pathname: window.location.pathname };
 
   const content = (
     <nav className="flex h-full flex-col p-4">
       <ul className="space-y-2">
         {navItems.map((item) => (
           <li key={item.href}>
-            <a
-              href={item.href}
-              className={`flex items-center space-x-2 rounded-md p-2 text-sm hover:bg-gray-100
-                ${location.pathname === item.href ? 'bg-gray-100' : ''}`}
+            <NavLink
+              to={item.href}
+              className={({ isActive }) =>
+                cn(
+                  'flex items-center space-x-2 rounded-md p-2 text-sm hover:bg-gray-100',
+                  isActive && 'bg-gray-100'
+                )
+              }
             >
               <item.icon className={ICON_SIZE} />
               <span>{item.label}</span>
-            </a>
+            </NavLink>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- use `<NavLink>` for sidebar routes
- manage active classes via `NavLink` instead of `window.location`
- update sidebar tests for new behaviour and add navigation test

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6841f9d511b8832e9689f55be602f602