### PR TITLE
Remove search page item from sidebar

### DIFF
--- a/src/features/navigation/components/Sidebar.tsx
+++ b/src/features/navigation/components/Sidebar.tsx
@@ -9,7 +9,6 @@ import {
   User,
   LogOut,
   Bell,
-  Search,
   HelpCircle
 } from "lucide-react";
 import { NavLink } from 'react-router-dom';
@@ -146,21 +145,15 @@ const navItems = [
     icon: BookOpen,
     badge: "12"
   },
-  { 
-    href: "/notifications", 
-    label: "Notifications", 
+  {
+    href: "/notifications",
+    label: "Notifications",
     icon: Bell,
     badge: "3"
   },
-  { 
-    href: "/search", 
-    label: "Search", 
-    icon: Search,
-    badge: null
-  },
-  { 
-    href: "/settings", 
-    label: "Settings", 
+  {
+    href: "/settings",
+    label: "Settings",
     icon: Settings,
     badge: null
   },


### PR DESCRIPTION
## Summary
- remove `Search` item from sidebar navigation

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842d05fb68c832ea77a50e5b981bc9f