### PR TITLE
Remove Help & Support from sidebar

### DIFF
--- a/src/features/navigation/components/Sidebar.tsx
+++ b/src/features/navigation/components/Sidebar.tsx
@@ -10,7 +10,6 @@ import {
   LogOut,
   Bell,
   Search,
-  HelpCircle
 } from "lucide-react";
 import { NavLink } from 'react-router-dom';
 import { cn } from '@/lib/utils';
@@ -162,12 +161,6 @@ const navItems = [
     href: "/settings", 
     label: "Settings", 
     icon: Settings,
-    badge: null
-  },
-  { 
-    href: "/help", 
-    label: "Help & Support", 
-    icon: HelpCircle,
     badge: null
   },
 ];


### PR DESCRIPTION
## Summary
- remove HelpCircle icon import
- remove Help & Support nav item

## Testing
- `npx vitest run --reporter dot`

------
https://chatgpt.com/codex/tasks/task_e_6842d085c394832eaaf4d4cf587c0f97