### PR TITLE
Fix lint issues and typing

### DIFF
--- a/src/app/AuthContext.tsx
+++ b/src/app/AuthContext.tsx
@@ -61,13 +61,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     try {
       const { error } = await supabase.auth.signInWithPassword({ email, password });
       if (error) throw error;
-    } catch (error: any) {
+  } catch (error: unknown) {
+      const err = error as Error;
       toast({
         variant: "destructive",
         title: "Sign in failed",
-        description: error.message || "An error occurred during sign in",
+        description: err.message || "An error occurred during sign in",
       });
-      throw error;
+      throw err;
     }
   };
 
@@ -86,24 +87,26 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         title: "Account created",
         description: "Please check your email to verify your account",
       });
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const err = error as Error;
       toast({
         variant: "destructive",
         title: "Sign up failed",
-        description: error.message || "An error occurred during sign up",
+        description: err.message || "An error occurred during sign up",
       });
-      throw error;
+      throw err;
     }
   };
 
   const signOut = async () => {
     try {
       await supabase.auth.signOut();
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const err = error as Error;
       toast({
         variant: "destructive",
         title: "Sign out failed",
-        description: error.message || "An error occurred during sign out",
+        description: err.message || "An error occurred during sign out",
       });
     }
   };
@@ -126,13 +129,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         title: "Profile updated",
         description: "Your profile has been updated successfully",
       });
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const err = error as Error;
       toast({
         variant: "destructive",
         title: "Profile update failed",
-        description: error.message || "An error occurred while updating your profile",
+        description: err.message || "An error occurred while updating your profile",
       });
-      throw error;
+      throw err;
     }
   };
 

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,8 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps =
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/features/cases/__tests__/InteractiveBodyDiagram.test.tsx
+++ b/src/features/cases/__tests__/InteractiveBodyDiagram.test.tsx
@@ -12,7 +12,7 @@ class ResizeObserver {
   unobserve() {}
   disconnect() {}
 }
-(global as any).ResizeObserver = ResizeObserver;
+(global as unknown as { ResizeObserver: typeof ResizeObserver }).ResizeObserver = ResizeObserver;
 
 describe('InteractiveBodyDiagram severity filter', () => {
   it('shows only critical parts when filter is set to critical', () => {

--- a/src/features/cases/__tests__/InteractiveVitalsCard.test.tsx
+++ b/src/features/cases/__tests__/InteractiveVitalsCard.test.tsx
@@ -13,7 +13,7 @@ beforeAll(() => {
     unobserve() {}
     disconnect() {}
   }
-  // @ts-ignore
+  // @ts-expect-error jsdom environment lacks ResizeObserver
   global.ResizeObserver = ResizeObserver;
 });
 

--- a/src/features/cases/create/ClinicalDetailStep.tsx
+++ b/src/features/cases/create/ClinicalDetailStep.tsx
@@ -21,7 +21,10 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Textarea } from "@/components/ui/textarea";
-import { InteractiveBodyDiagram } from "@/features/cases/InteractiveBodyDiagram";
+import {
+  InteractiveBodyDiagram,
+  BodyPartSelection,
+} from "@/features/cases/InteractiveBodyDiagram";
 import { SystemReviewChecklist } from "@/features/cases/SystemReviewChecklist";
 import { VitalsCard } from "@/features/cases/VitalsCard";
 import { LabResultsCard } from "@/features/cases/LabResultsCard";
@@ -151,13 +154,13 @@ export const ClinicalDetailStep = memo(function ClinicalDetailStep<
    * ─────────── Handlers ————————————————————————————————————————————————
    */
   const handleBodyPartSelected = useCallback(
-    (selection: any) => {
+    (selection: BodyPartSelection) => {
       const partName = selection.name || selection.id;
       setValue(
         "selectedBodyParts" as Path<T>,
         selectedBodyParts.includes(partName)
-          ? (selectedBodyParts.filter((p) => p !== partName) as any)
-          : ([...selectedBodyParts, partName] as any),
+          ? (selectedBodyParts.filter((p) => p !== partName) as string[])
+          : ([...selectedBodyParts, partName] as string[]),
         { shouldValidate: true },
       );
     },
@@ -166,24 +169,35 @@ export const ClinicalDetailStep = memo(function ClinicalDetailStep<
 
   const setSystemSymptoms = useCallback(
     (val: Record<string, string[]>) =>
-      setValue("systemSymptoms" as Path<T>, val as any, { shouldValidate: true }),
+      setValue("systemSymptoms" as Path<T>, val as Record<string, string[]>, {
+        shouldValidate: true,
+      }),
     [setValue],
   );
 
   const setVitals = useCallback(
     (v: Record<string, string>) =>
-      setValue("vitals" as Path<T>, v as any, { shouldValidate: true }),
+      setValue("vitals" as Path<T>, v as Record<string, string>, {
+        shouldValidate: true,
+      }),
     [setValue],
   );
 
   const setLabResults = useCallback(
-    (labs: any[]) => setValue("labResults" as Path<T>, labs as any, { shouldValidate: true }),
+    (labs: ComponentLabTest[]) =>
+      setValue("labResults" as Path<T>, labs as ComponentLabTest[], {
+        shouldValidate: true,
+      }),
     [setValue],
   );
 
   const setRadiology = useCallback(
-    (imgs: any[]) =>
-      setValue("radiologyExams" as Path<T>, imgs as any, { shouldValidate: true }),
+    (imgs: ComponentRadiologyExam[]) =>
+      setValue(
+        "radiologyExams" as Path<T>,
+        imgs as ComponentRadiologyExam[],
+        { shouldValidate: true },
+      ),
     [setValue],
   );
 

--- a/src/features/cases/create/LearningPointsStep.tsx
+++ b/src/features/cases/create/LearningPointsStep.tsx
@@ -123,7 +123,7 @@ export const LearningPointsStep = memo(function LearningPointsStep<
 >({ control, className, maxLinks = 8 }: LearningPointsStepProps<T>) {
   const { fields, append, remove } = useFieldArray({
     control,
-    name: "resourceLinks" as any, // Type assertion to resolve the complex type error
+    name: "resourceLinks" as Path<T>,
   });
 
   return (
@@ -212,7 +212,9 @@ export const LearningPointsStep = memo(function LearningPointsStep<
           <Button
             type="button"
             variant="outline"
-            onClick={() => append({ url: "", description: "" } as any)}
+            onClick={() =>
+              append({ url: "", description: "" } as unknown as { url: string; description?: string })
+            }
             disabled={fields.length >= maxLinks}
           >
             <PlusCircle className="mr-2 h-4 w-4" /> Add Resource Link

--- a/src/features/navigation/components/Sidebar.tsx
+++ b/src/features/navigation/components/Sidebar.tsx
@@ -223,7 +223,10 @@ const UserProfile: React.FC<{ collapsed: boolean; isMobile: boolean }> = ({ coll
     return null;
   }
 
-  const fullName = (user.user_metadata as any)?.full_name || user.email;
+  interface UserMetadata {
+    full_name?: string;
+  }
+  const fullName = (user.user_metadata as UserMetadata)?.full_name || user.email;
 
   if (collapsed && !isMobile) {
     return (

--- a/src/hooks/use-supabase-cases.ts
+++ b/src/hooks/use-supabase-cases.ts
@@ -19,14 +19,14 @@ interface LabTest {
   value: string;
   unit?: string;
   normalRange?: string;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 interface RadiologyExam {
   type: string;
   findings: string;
   impression?: string;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 type DiagnosisStatus = 'pending' | 'confirmed' | 'ruled_out';
@@ -261,13 +261,23 @@ function transformDbCaseToMedicalCase(dbCase: Record<string, unknown>): MedicalC
     vitals: (dbCase.vitals || {}) as Record<string, string>,
     symptoms: (dbCase.symptoms || {}) as Record<string, boolean>,
     urinarySymptoms: (dbCase.urinary_symptoms || []) as string[],
-    labTests: ((dbCase.lab_tests || []) as any[]).map((test: any) => ({
+    labTests: ((dbCase.lab_tests || []) as {
+      id?: string;
+      name?: string;
+      value?: string;
+      unit?: string;
+    }[]).map((test) => ({
       id: test.id || `lab-${Date.now()}-${Math.random()}`,
       name: test.name || '',
       value: test.value || '',
       unit: test.unit || ''
     })) as ComponentLabTest[],
-    radiologyExams: ((dbCase.radiology_exams || []) as any[]).map((exam: any) => ({
+    radiologyExams: ((dbCase.radiology_exams || []) as {
+      id?: string;
+      modality?: string;
+      type?: string;
+      findings?: string;
+    }[]).map((exam) => ({
       id: exam.id || `rad-${Date.now()}-${Math.random()}`,
       modality: exam.modality || exam.type || '',
       findings: exam.findings || ''

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -52,12 +52,17 @@ const Settings = () => {
     },
   });
 
+  interface UserMetadata {
+    full_name?: string;
+    specialty?: string;
+  }
+
   useEffect(() => {
     form.reset({
-      full_name: (user?.user_metadata as any)?.full_name || "",
-      specialty: (user?.user_metadata as any)?.specialty || "",
+      full_name: (user?.user_metadata as UserMetadata)?.full_name || "",
+      specialty: (user?.user_metadata as UserMetadata)?.specialty || "",
     });
-  }, [user]);
+  }, [user, form]);
 
   const onSubmit = async (data: ProfileFormData) => {
     try {
@@ -66,8 +71,9 @@ const Settings = () => {
         specialty: data.specialty,
       });
       toast.success("Profile updated");
-    } catch (error: any) {
-      toast.error(error.message || "Failed to update profile");
+    } catch (error: unknown) {
+      const err = error as Error;
+      toast.error(err.message || "Failed to update profile");
     }
   };
 

--- a/src/shared/ui/input.tsx
+++ b/src/shared/ui/input.tsx
@@ -3,8 +3,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {}
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, ...props }, ref) => {


### PR DESCRIPTION
## Summary
- replace `any` with safer types in several files
- update user metadata handling in Settings and Sidebar
- clarify custom component props
- add ResizeObserver typings in tests
- adjust hooks with typed parameters

## Testing
- `npm run lint`
- `npm test` *(fails: Bell is not defined in Sidebar.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6842d4d507d0832e9f4bbe20b2002693