### PR TITLE
Fix lint issues and refactor types

### DIFF
--- a/src/app/AuthContext.tsx
+++ b/src/app/AuthContext.tsx
@@ -61,11 +61,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     try {
       const { error } = await supabase.auth.signInWithPassword({ email, password });
       if (error) throw error;
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const err = error as Error;
       toast({
         variant: "destructive",
         title: "Sign in failed",
-        description: error.message || "An error occurred during sign in",
+        description: err.message || "An error occurred during sign in",
       });
       throw error;
     }
@@ -73,24 +74,25 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const signUp = async (email: string, password: string, fullName?: string) => {
     try {
-      const { error } = await supabase.auth.signUp({ 
-        email, 
+      const { error } = await supabase.auth.signUp({
+        email,
         password,
         options: {
           data: { full_name: fullName }
         }
       });
       if (error) throw error;
-      
+
       toast({
         title: "Account created",
         description: "Please check your email to verify your account",
       });
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const err = error as Error;
       toast({
         variant: "destructive",
         title: "Sign up failed",
-        description: error.message || "An error occurred during sign up",
+        description: err.message || "An error occurred during sign up",
       });
       throw error;
     }
@@ -99,11 +101,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const signOut = async () => {
     try {
       await supabase.auth.signOut();
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const err = error as Error;
       toast({
         variant: "destructive",
         title: "Sign out failed",
-        description: error.message || "An error occurred during sign out",
+        description: err.message || "An error occurred during sign out",
       });
     }
   };
@@ -126,11 +129,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         title: "Profile updated",
         description: "Your profile has been updated successfully",
       });
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const err = error as Error;
       toast({
         variant: "destructive",
         title: "Profile update failed",
-        description: error.message || "An error occurred while updating your profile",
+        description: err.message || "An error occurred while updating your profile",
       });
       throw error;
     }

--- a/src/components/ui/button-variants.ts
+++ b/src/components/ui/button-variants.ts
@@ -1,0 +1,28 @@
+import { cva } from "class-variance-authority";
+
+export const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 px-3",
+        lg: "h-11 px-8",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+);
+

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,38 +1,10 @@
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
 import { Loader2 } from "lucide-react"
 
 import { cn } from "@/lib/utils"
-
-const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
-  {
-    variants: {
-      variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
-        destructive:
-          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
-        outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
-        secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
-      },
-      size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 px-3",
-        lg: "h-11 px-8",
-        icon: "h-10 w-10",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  }
-)
+import { buttonVariants } from "./button-variants"
+import type { VariantProps } from "class-variance-authority"
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/sonner-toast.ts
+++ b/src/components/ui/sonner-toast.ts
@@ -1,0 +1,2 @@
+export { toast } from "sonner";
+

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,5 +1,5 @@
 
-import { Toaster as Sonner, toast } from "sonner"
+import { Toaster as Sonner } from "sonner"
 import { useTheme } from "@/app/ThemeContext"
 
 type ToasterProps = React.ComponentProps<typeof Sonner>
@@ -27,4 +27,4 @@ const Toaster = ({ ...props }: ToasterProps) => {
   )
 }
 
-export { Toaster, toast }
+export { Toaster }

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,8 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps =
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/features/cases/__tests__/InteractiveBodyDiagram.test.tsx
+++ b/src/features/cases/__tests__/InteractiveBodyDiagram.test.tsx
@@ -12,7 +12,7 @@ class ResizeObserver {
   unobserve() {}
   disconnect() {}
 }
-(global as any).ResizeObserver = ResizeObserver;
+(globalThis as unknown as { ResizeObserver: typeof ResizeObserver }).ResizeObserver = ResizeObserver;
 
 describe('InteractiveBodyDiagram severity filter', () => {
   it('shows only critical parts when filter is set to critical', () => {

--- a/src/features/cases/__tests__/InteractiveVitalsCard.test.tsx
+++ b/src/features/cases/__tests__/InteractiveVitalsCard.test.tsx
@@ -13,7 +13,7 @@ beforeAll(() => {
     unobserve() {}
     disconnect() {}
   }
-  // @ts-ignore
+  // @ts-expect-error ResizeObserver is not available in jsdom
   global.ResizeObserver = ResizeObserver;
 });
 

--- a/src/features/cases/create/ClinicalDetailConfig.ts
+++ b/src/features/cases/create/ClinicalDetailConfig.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+import {
+  User as UserIcon,
+  Brain as BrainIcon,
+  TestTube as TestTubeIcon,
+} from "lucide-react";
+
+export const clinicalDetailStepSchema = z.object({
+  patientHistory: z.string().optional(),
+  selectedBodyParts: z.array(z.string()).default([]),
+  systemSymptoms: z.record(z.array(z.string())).default({}),
+  vitals: z.record(z.string()).default({}),
+  physicalExam: z.string().optional(),
+  labResults: z
+    .array(
+      z.object({
+        id: z.string(),
+        name: z.string(),
+        value: z.string(),
+        unit: z.string(),
+      }),
+    )
+    .default([]),
+  radiologyExams: z
+    .array(
+      z.object({
+        id: z.string(),
+        modality: z.string(),
+        findings: z.string(),
+      }),
+    )
+    .default([]),
+});
+export type ClinicalDetailFormData = z.infer<typeof clinicalDetailStepSchema>;
+
+export const TAB_ITEMS = [
+  {
+    value: "history",
+    label: "History & Exam",
+    icon: UserIcon,
+  },
+  {
+    value: "systems",
+    label: "Systems Review",
+    icon: BrainIcon,
+  },
+  {
+    value: "diagnostics",
+    label: "Diagnostics",
+    icon: TestTubeIcon,
+  },
+] as const;
+export type TabValue = (typeof TAB_ITEMS)[number]["value"];
+

--- a/src/features/cases/create/ClinicalDetailStep.tsx
+++ b/src/features/cases/create/ClinicalDetailStep.tsx
@@ -13,6 +13,12 @@ import {
 } from "react-hook-form";
 import { z } from "zod";
 import {
+  clinicalDetailStepSchema,
+  type ClinicalDetailFormData,
+  TAB_ITEMS,
+  type TabValue,
+} from "./ClinicalDetailConfig";
+import {
   FormField,
   FormItem,
   FormLabel,
@@ -42,63 +48,21 @@ import {
   Microscope as MicroscopeIcon,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import type { LabTest as ComponentLabTest, RadiologyExam as ComponentRadiologyExam } from "@/types/case";
 
 /**
  * ────────────────────────────────────────────────────────────────────────────────
  * SCHEMA
  * ────────────────────────────────────────────────────────────────────────────────
  */
-export const clinicalDetailStepSchema = z.object({
-  patientHistory: z.string().optional(),
-  selectedBodyParts: z.array(z.string()).default([]),
-  systemSymptoms: z.record(z.array(z.string())).default({}),
-  vitals: z.record(z.string()).default({}),
-  physicalExam: z.string().optional(),
-  labResults: z
-    .array(
-      z.object({
-        id: z.string(),
-        name: z.string(),
-        value: z.string(),
-        unit: z.string(),
-      }),
-    )
-    .default([]),
-  radiologyExams: z
-    .array(
-      z.object({
-        id: z.string(),
-        modality: z.string(),
-        findings: z.string(),
-      }),
-    )
-    .default([]),
-});
-export type ClinicalDetailFormData = z.infer<typeof clinicalDetailStepSchema>;
+
 
 /**
  * ────────────────────────────────────────────────────────────────────────────────
- * CONSTANTS & TYPES
+ * TYPES
  * ────────────────────────────────────────────────────────────────────────────────
  */
-const TAB_ITEMS = [
-  {
-    value: "history",
-    label: "History & Exam",
-    icon: UserIcon,
-  },
-  {
-    value: "systems",
-    label: "Systems Review",
-    icon: BrainIcon,
-  },
-  {
-    value: "diagnostics",
-    label: "Diagnostics",
-    icon: TestTubeIcon,
-  },
-] as const;
-export type TabValue = (typeof TAB_ITEMS)[number]["value"];
+type TabValue = (typeof TAB_ITEMS)[number]["value"];
 
 interface ClinicalDetailStepProps<T extends FieldValues = ClinicalDetailFormData> {
   control: Control<T>;
@@ -151,13 +115,13 @@ export const ClinicalDetailStep = memo(function ClinicalDetailStep<
    * ─────────── Handlers ————————————————————————————————————————————————
    */
   const handleBodyPartSelected = useCallback(
-    (selection: any) => {
+    (selection: { id?: string; name?: string }) => {
       const partName = selection.name || selection.id;
       setValue(
         "selectedBodyParts" as Path<T>,
-        selectedBodyParts.includes(partName)
-          ? (selectedBodyParts.filter((p) => p !== partName) as any)
-          : ([...selectedBodyParts, partName] as any),
+        (selectedBodyParts.includes(partName)
+          ? selectedBodyParts.filter((p) => p !== partName)
+          : [...selectedBodyParts, partName]) as FieldValues[Path<T>],
         { shouldValidate: true },
       );
     },
@@ -166,24 +130,24 @@ export const ClinicalDetailStep = memo(function ClinicalDetailStep<
 
   const setSystemSymptoms = useCallback(
     (val: Record<string, string[]>) =>
-      setValue("systemSymptoms" as Path<T>, val as any, { shouldValidate: true }),
+      setValue("systemSymptoms" as Path<T>, val as FieldValues[Path<T>], { shouldValidate: true }),
     [setValue],
   );
 
   const setVitals = useCallback(
     (v: Record<string, string>) =>
-      setValue("vitals" as Path<T>, v as any, { shouldValidate: true }),
+      setValue("vitals" as Path<T>, v as FieldValues[Path<T>], { shouldValidate: true }),
     [setValue],
   );
 
   const setLabResults = useCallback(
-    (labs: any[]) => setValue("labResults" as Path<T>, labs as any, { shouldValidate: true }),
+    (labs: ComponentLabTest[]) => setValue("labResults" as Path<T>, labs as FieldValues[Path<T>], { shouldValidate: true }),
     [setValue],
   );
 
   const setRadiology = useCallback(
-    (imgs: any[]) =>
-      setValue("radiologyExams" as Path<T>, imgs as any, { shouldValidate: true }),
+    (imgs: ComponentRadiologyExam[]) =>
+      setValue("radiologyExams" as Path<T>, imgs as FieldValues[Path<T>], { shouldValidate: true }),
     [setValue],
   );
 

--- a/src/features/cases/create/LearningPointsStep.tsx
+++ b/src/features/cases/create/LearningPointsStep.tsx
@@ -123,7 +123,7 @@ export const LearningPointsStep = memo(function LearningPointsStep<
 >({ control, className, maxLinks = 8 }: LearningPointsStepProps<T>) {
   const { fields, append, remove } = useFieldArray({
     control,
-    name: "resourceLinks" as any, // Type assertion to resolve the complex type error
+    name: "resourceLinks" as Path<T>,
   });
 
   return (
@@ -212,7 +212,7 @@ export const LearningPointsStep = memo(function LearningPointsStep<
           <Button
             type="button"
             variant="outline"
-            onClick={() => append({ url: "", description: "" } as any)}
+            onClick={() => append({ url: "", description: "" } as unknown as FieldValues[Path<T>])}
             disabled={fields.length >= maxLinks}
           >
             <PlusCircle className="mr-2 h-4 w-4" /> Add Resource Link

--- a/src/features/cases/create/index.ts
+++ b/src/features/cases/create/index.ts
@@ -1,6 +1,7 @@
 export { CaseInfoStep, caseInfoSchema } from './CaseInfoStep';
 export { PatientStep, patientStepSchema } from './PatientStep';
-export { ClinicalDetailStep, clinicalDetailStepSchema } from './ClinicalDetailStep';
+export { ClinicalDetailStep } from './ClinicalDetailStep';
+export { clinicalDetailStepSchema } from './ClinicalDetailConfig';
 export { LearningPointsStep, learningPointsStepSchema } from './LearningPointsStep';
 export { FormContainer } from './FormContainer';
 export type { StepMeta } from './FormContainer';

--- a/src/features/navigation/components/Sidebar.tsx
+++ b/src/features/navigation/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Menu,
   X,
@@ -13,27 +13,9 @@ import {
 import { NavLink } from 'react-router-dom';
 import { cn } from '@/lib/utils';
 import { useAuth } from '@/app/AuthContext';
+import type { UserMetadata } from '@/types/auth';
 import { SIDEBAR_CONFIG, getInitialSidebarState, saveSidebarState } from "@/constants/sidebar";
-
-interface SidebarContextValue {
-  open: boolean;
-  isMobile: boolean;
-  collapsed: boolean;
-  toggle: () => void;
-  openSidebar: () => void;
-  closeSidebar: () => void;
-  toggleCollapsed: () => void;
-}
-
-const SidebarContext = createContext<SidebarContextValue>({
-  open: false,
-  isMobile: false,
-  collapsed: false,
-  toggle: () => {},
-  openSidebar: () => {},
-  closeSidebar: () => {},
-  toggleCollapsed: () => {},
-});
+import { SidebarContext, useSidebar, type SidebarContextValue } from './SidebarContext';
 
 const ICON_SIZE = "w-5 h-5";
 
@@ -109,8 +91,6 @@ export const SidebarProvider: React.FC<SidebarProviderProps> = ({ children }) =>
     </SidebarContext.Provider>
   );
 };
-
-export const useSidebar = () => useContext(SidebarContext);
 
 export const SidebarTrigger = ({ className }: { className?: string }) => {
   const { toggle } = useSidebar();
@@ -223,7 +203,7 @@ const UserProfile: React.FC<{ collapsed: boolean; isMobile: boolean }> = ({ coll
     return null;
   }
 
-  const fullName = (user.user_metadata as any)?.full_name || user.email;
+  const fullName = (user.user_metadata as UserMetadata)?.full_name || user.email;
 
   if (collapsed && !isMobile) {
     return (

--- a/src/features/navigation/components/SidebarContext.tsx
+++ b/src/features/navigation/components/SidebarContext.tsx
@@ -1,0 +1,24 @@
+import { createContext, useContext } from "react";
+
+export interface SidebarContextValue {
+  open: boolean;
+  isMobile: boolean;
+  collapsed: boolean;
+  toggle: () => void;
+  openSidebar: () => void;
+  closeSidebar: () => void;
+  toggleCollapsed: () => void;
+}
+
+export const SidebarContext = createContext<SidebarContextValue>({
+  open: false,
+  isMobile: false,
+  collapsed: false,
+  toggle: () => {},
+  openSidebar: () => {},
+  closeSidebar: () => {},
+  toggleCollapsed: () => {},
+});
+
+export const useSidebar = () => useContext(SidebarContext);
+

--- a/src/features/navigation/index.ts
+++ b/src/features/navigation/index.ts
@@ -1,3 +1,4 @@
 
-export { default as Sidebar, SidebarProvider, SidebarTrigger, useSidebar } from './components/Sidebar';
+export { default as Sidebar, SidebarProvider, SidebarTrigger } from './components/Sidebar';
+export { useSidebar } from './components/SidebarContext';
 export { AppLayout } from './components/AppLayout';

--- a/src/hooks/use-supabase-cases.ts
+++ b/src/hooks/use-supabase-cases.ts
@@ -14,19 +14,20 @@ type DbDiagnosis = Database['public']['Tables']['diagnoses']['Row'];
 type DbResource = Database['public']['Tables']['resources']['Row'];
 type DbCaseTag = Database['public']['Tables']['case_tags']['Row'];
 
-interface LabTest {
-  name: string;
-  value: string;
-  unit?: string;
-  normalRange?: string;
-  [key: string]: any;
+interface DbLabTest {
+  id?: string;
+  name?: string | null;
+  value?: string | null;
+  unit?: string | null;
+  normalRange?: string | null;
 }
 
-interface RadiologyExam {
-  type: string;
-  findings: string;
-  impression?: string;
-  [key: string]: any;
+interface DbRadiologyExam {
+  id?: string;
+  modality?: string | null;
+  type?: string | null;
+  findings?: string | null;
+  impression?: string | null;
 }
 
 type DiagnosisStatus = 'pending' | 'confirmed' | 'ruled_out';
@@ -261,16 +262,16 @@ function transformDbCaseToMedicalCase(dbCase: Record<string, unknown>): MedicalC
     vitals: (dbCase.vitals || {}) as Record<string, string>,
     symptoms: (dbCase.symptoms || {}) as Record<string, boolean>,
     urinarySymptoms: (dbCase.urinary_symptoms || []) as string[],
-    labTests: ((dbCase.lab_tests || []) as any[]).map((test: any) => ({
-      id: test.id || `lab-${Date.now()}-${Math.random()}`,
-      name: test.name || '',
-      value: test.value || '',
-      unit: test.unit || ''
+    labTests: ((dbCase.lab_tests || []) as DbLabTest[]).map((test) => ({
+      id: test.id ?? `lab-${Date.now()}-${Math.random()}`,
+      name: test.name ?? '',
+      value: test.value ?? '',
+      unit: test.unit ?? ''
     })) as ComponentLabTest[],
-    radiologyExams: ((dbCase.radiology_exams || []) as any[]).map((exam: any) => ({
-      id: exam.id || `rad-${Date.now()}-${Math.random()}`,
-      modality: exam.modality || exam.type || '',
-      findings: exam.findings || ''
+    radiologyExams: ((dbCase.radiology_exams || []) as DbRadiologyExam[]).map((exam) => ({
+      id: exam.id ?? `rad-${Date.now()}-${Math.random()}`,
+      modality: exam.modality ?? exam.type ?? '',
+      findings: exam.findings ?? ''
     })) as ComponentRadiologyExam[],
     diagnoses: ((dbCase.diagnoses as DbDiagnosis[]) || []).map((d: DbDiagnosis) => ({
       id: d.id,

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -3,6 +3,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { useAuth } from "@/app/AuthContext";
+import type { UserMetadata } from "@/types/auth";
 import { useTheme } from "@/app/ThemeContext";
 import { PageHeader } from "@/components/ui/page-header";
 import {
@@ -54,10 +55,10 @@ const Settings = () => {
 
   useEffect(() => {
     form.reset({
-      full_name: (user?.user_metadata as any)?.full_name || "",
-      specialty: (user?.user_metadata as any)?.specialty || "",
+      full_name: (user?.user_metadata as UserMetadata)?.full_name || "",
+      specialty: (user?.user_metadata as UserMetadata)?.specialty || "",
     });
-  }, [user]);
+  }, [user, form]);
 
   const onSubmit = async (data: ProfileFormData) => {
     try {
@@ -66,8 +67,9 @@ const Settings = () => {
         specialty: data.specialty,
       });
       toast.success("Profile updated");
-    } catch (error: any) {
-      toast.error(error.message || "Failed to update profile");
+    } catch (error: unknown) {
+      const err = error as Error;
+      toast.error(err.message || "Failed to update profile");
     }
   };
 

--- a/src/shared/ui/input.tsx
+++ b/src/shared/ui/input.tsx
@@ -3,8 +3,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {}
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, ...props }, ref) => {

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,6 @@
+export interface UserMetadata {
+  full_name?: string;
+  specialty?: string;
+  [key: string]: unknown;
+}
+


### PR DESCRIPTION
## Summary
- refine error handling in AuthContext
- split button variants to separate module
- convert empty interfaces to type aliases
- separate Sidebar context for fast refresh
- move clinical detail schema to its own file
- tidy hooks and settings types
- adjust tests for ESLint rules

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842d49d8464832eb2f1de395b509721