### PR TITLE
Fix dev server port in docs

### DIFF
--- a/LOCAL_HOSTING_GUIDE.md
+++ b/LOCAL_HOSTING_GUIDE.md
@@ -69,7 +69,7 @@ Finally, start the local development server:
     bun run dev
     ```
 
-This will typically make the application available at `http://localhost:5173` in your web browser. Check the terminal output for the exact URL.
+This will typically make the application available at `http://localhost:8080` in your web browser. Check the terminal output for the exact URL.
 
 ---
 


### PR DESCRIPTION
## Summary
- fix inconsistent port reference in LOCAL_HOSTING_GUIDE

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68436bc875e8832e9b53477dbfb6dcab