### PR TITLE
Add troubleshooting docs for missing node modules

### DIFF
--- a/LOCAL_HOSTING_GUIDE.md
+++ b/LOCAL_HOSTING_GUIDE.md
@@ -75,6 +75,10 @@ Finally, start the local development server:
 
 This will typically make the application available at `http://localhost:8080` in your web browser. Check the terminal output for the exact URL.
 
+## Troubleshooting
+If `npm run dev` fails with an error about `@vitejs/plugin-react` or other missing modules, run `npm install` (or `bun install`) before starting the dev server.
+
+
 ---
 
 Now you can access the application locally, make code changes, and see them reflected in real-time.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ bun run dev
 
 This will start the development server, typically at `http://localhost:8080`.
 
+### Troubleshooting
+If `npm run dev` fails with an error about `@vitejs/plugin-react` or other missing modules, run `npm install` (or `bun install`) to install dependencies before starting the dev server.
+
+
 ## Available Scripts
 
 The `package.json` file defines the following scripts:


### PR DESCRIPTION
## Summary
- mention npm install fix for @vitejs/plugin-react errors in README
- add the same note to LOCAL_HOSTING_GUIDE

## Testing
- `npx vitest run` *(fails: vitest output indicates success for some tests, but process hung)*

------
https://chatgpt.com/codex/tasks/task_e_68443366ea20832e92d5f56f617a9043