### PR TITLE
Refactor: Change import style for getCaseById in CaseDetail

### DIFF
--- a/src/data/mock-data.ts
+++ b/src/data/mock-data.ts
@@ -1,4 +1,3 @@
-
 import { MedicalCase, CaseTag } from "@/types/case";
 
 // Generate a random ID

--- a/src/pages/CaseDetail.tsx
+++ b/src/pages/CaseDetail.tsx
@@ -1,6 +1,6 @@
 import { useParams, Link, useNavigate } from "react-router-dom";
 import { format } from "date-fns";
-import { getCaseById } from "@/data/mock-data";
+import * as MockData from "@/data/mock-data";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -56,7 +56,7 @@ const CaseDetail = () => {
     }
     
     // If not found in localStorage, check mock data
-    const mockCase = getCaseById(id);
+    const mockCase = MockData.getCaseById(id);
     if (mockCase) {
       console.log("Found case in mock data:", mockCase);
       setMedicalCase(mockCase);


### PR DESCRIPTION
This commit attempts to resolve an "does not provide an export named 'getCaseById'" error.

Changes:
- Modified `src/pages/CaseDetail.tsx` to use a namespace import (`import * as MockData from "@/data/mock-data";`) for functions from `mock-data.ts`. The call to `getCaseById` was updated accordingly.
- Verified that `getCaseById` is correctly exported from `src/data/mock-data.ts`.

This change in import style is intended to bypass potential issues with named exports that might have been causing the runtime error.