### PR TITLE
Refactor RecentActivityList component export

### DIFF
--- a/src/components/RecentActivityList.tsx
+++ b/src/components/RecentActivityList.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 
-function RecentActivityList() {
+export default function RecentActivityList() {
   // 1. Initialize state with an empty array
   const [activities, setActivities] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -66,5 +66,3 @@ function RecentActivityList() {
     </div>
   );
 }
-
-export default RecentActivityList;


### PR DESCRIPTION
I moved the default export to be part of the function declaration for RecentActivityList in `src/components/RecentActivityList.tsx`.

This addresses the issue of how the component is exported, ensuring the export is combined with the declaration, which is a common pattern and aligns with the implied correction from the issue description.