### PR TITLE
Fix RecentActivityList export order

### DIFF
--- a/src/features/dashboard/components/RecentActivityList.tsx
+++ b/src/features/dashboard/components/RecentActivityList.tsx
@@ -7,7 +7,7 @@ const activityItems = [
   { id: 3, description: "Settings updated: Notifications enabled", time: "3 days ago" },
 ];
 
-export const RecentActivityList = () => {
+const RecentActivityList: React.FC = () => {
   return (
     <Card>
       <CardHeader>


### PR DESCRIPTION
## Summary
- declare the `RecentActivityList` component before exporting it

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68456a9ecc20832e9be2f09b42421686