### PR TITLE
Allow skipping validation when jumping between steps

### DIFF
--- a/src/pages/CreateCaseFlow.tsx
+++ b/src/pages/CreateCaseFlow.tsx
@@ -169,29 +169,12 @@ const CreateCaseFlow = () => {
     setCurrentStepIndex((prev) => Math.max(prev - 1, 0));
   };
 
-  const handleStepClick = async (stepId: string) => {
-    const targetStepIndex = STEPS.findIndex(step => step.id === stepId);
+  const handleStepClick = (stepId: string) => {
+    const targetStepIndex = STEPS.findIndex((step) => step.id === stepId);
     if (targetStepIndex < 0 || targetStepIndex === currentStepIndex) return;
 
-    if (targetStepIndex < currentStepIndex || targetStepIndex <= highestValidatedStep + 1) {
-        if (targetStepIndex > currentStepIndex && targetStepIndex > highestValidatedStep) {
-            for (let i = currentStepIndex; i < targetStepIndex; i++) {
-                const fieldsToValidate = STEPS[i].fields;
-                if (fieldsToValidate.length > 0) {
-                    const isValid = await trigger(fieldsToValidate);
-                    if (!isValid) {
-                        setCurrentStepIndex(i);
-                        toast.error(`Please complete step ${i + 1} before proceeding`);
-                        return;
-                    }
-                    setHighestValidatedStep(Math.max(highestValidatedStep, i));
-                }
-            }
-        }
-        setCurrentStepIndex(targetStepIndex);
-    } else {
-        toast.warning("Please complete the current step first");
-    }
+    // Allow direct navigation without validating intermediate steps
+    setCurrentStepIndex(targetStepIndex);
   };
   
   const onSubmit: SubmitHandler<CombinedCaseFormData> = async (data) => {
@@ -262,12 +245,13 @@ const CreateCaseFlow = () => {
           <FormContainer
             currentStep={currentStepIndex + 1}
             totalSteps={STEPS.length}
-            steps={STEPS.map((step, index) => ({ 
-                id: step.id, 
-                label: step.label, 
+            steps={STEPS.map((step, index) => ({
+                id: step.id,
+                label: step.label,
                 icon: step.icon,
                 isCompleted: index <= highestValidatedStep,
-                isNavigable: index <= highestValidatedStep + 1 || index < currentStepIndex,
+                // Steps remain clickable even if not yet validated
+                isNavigable: true,
             }))}
             onStepClick={handleStepClick}
           >


### PR DESCRIPTION
## Summary
- let the progress indicator navigate without checking previous steps
- mark all steps as navigable

## Testing
- `npm test`
- `npm run lint` *(fails: no-irregular-whitespace and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684575be203c832ead7c8eb3a4e9523f