### PR TITLE
feat: Allow form progression without completing required fields

### DIFF
--- a/src/features/cases/create/CaseInfoStep.tsx
+++ b/src/features/cases/create/CaseInfoStep.tsx
@@ -28,9 +28,9 @@ import { cn } from "@/lib/utils";
  * ────────────────────────────────────────────────────────────────────────────────
  */
 export const caseInfoSchema = z.object({
-  caseTitle: z.string().min(3, "Case title must be at least 3 characters."),
-  chiefComplaint: z.string().min(5, "Chief complaint must be at least 5 characters."),
-  specialty: z.string().min(1, "Please select a medical specialty."),
+  caseTitle: z.string().min(3, "Case title must be at least 3 characters.").optional(),
+  chiefComplaint: z.string().min(5, "Chief complaint must be at least 5 characters.").optional(),
+  specialty: z.string().optional(),
 });
 
 export type CaseInfoFormData = z.infer<typeof caseInfoSchema>;

--- a/src/features/cases/create/PatientStep.tsx
+++ b/src/features/cases/create/PatientStep.tsx
@@ -35,7 +35,7 @@ import { cn } from "@/lib/utils";
  * ────────────────────────────────────────────────────────────────────────────────
  */
 export const patientStepSchema = z.object({
-  patientName: z.string().min(2, "Patient name must be at least 2 characters."),
+  patientName: z.string().min(2, "Patient name must be at least 2 characters.").optional(),
   medicalRecordNumber: z.string().optional(),
   patientAge: z
     .union([z.string().length(0), z.number().int().min(0).max(150)])

--- a/src/pages/CreateCaseFlow.tsx
+++ b/src/pages/CreateCaseFlow.tsx
@@ -148,13 +148,7 @@ const CreateCaseFlow = () => {
   const handleNext = async () => {
     const fieldsToValidate = STEPS[currentStepIndex].fields;
     if (fieldsToValidate.length > 0) {
-        const isValid = await trigger(fieldsToValidate);
-        if (!isValid) {
-        toast.error("Please fix the errors before proceeding", {
-          description: "Some required fields are missing or invalid"
-        });
-        return;
-        }
+        await trigger(fieldsToValidate); // Keep this line to show validation messages
     }
     
     setHighestValidatedStep(Math.max(highestValidatedStep, currentStepIndex));


### PR DESCRIPTION
I've modified the new case creation flow so you can navigate between steps using the 'Next' button without being forced to fill all previously mandatory fields.

Key changes:
- I updated Zod schemas for 'Case Info' and 'Patient' steps (`CaseInfoStep.tsx`, `PatientStep.tsx`) to make fields like `caseTitle`, `chiefComplaint`, `specialty`, and `patientName` optional.
- I adjusted the `handleNext` logic in `CreateCaseFlow.tsx` to trigger validation (displaying field errors if content is invalid) but not block navigation if validation fails.
- I ensured that direct step navigation via clicking on step indicators remains functional.

This change allows you to draft cases more flexibly, filling information in any order and saving progress without premature validation blockages. Final form submission will still be validated against the overall schema.