### PR TITLE
Fix: Allow text wrapping in QuickStartPanel description

### DIFF
--- a/src/features/dashboard/components/QuickStartPanel.tsx
+++ b/src/features/dashboard/components/QuickStartPanel.tsx
@@ -58,7 +58,7 @@ export const QuickStartPanel = () => {
               >
                 <div className="flex items-start space-x-3">
                   <IconComponent className={`${ICON_SIZE} mt-0.5 flex-shrink-0`} />
-                  <div className="text-left">
+                  <div className="text-left flex-wrap whitespace-normal">
                     <div className="font-medium">{action.title}</div>
                     <div className="text-sm font-medium text-muted-foreground mt-1">
                       {action.description}


### PR DESCRIPTION
The description text within the QuickStartPanel component's action buttons could sometimes overflow its container. This change applies `flex-wrap` and `whitespace-normal` utility classes to the description's parent div, allowing the text to wrap to the next line as needed.

This addresses the issue where longer descriptions might be cut off or disrupt the layout of the QuickAction cards.