### PR TITLE
I've updated the positions of the toast components.

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -45,7 +45,7 @@ const App = () => {
           <ThemeProvider>
             <AuthProvider>
               <Toaster />
-              <Sonner />
+              <Sonner position="top-right" />
               <BrowserRouter>
                 <SidebarProvider>
                   <Routes>

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -14,7 +14,7 @@ const ToastViewport = React.forwardRef<
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
-      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:top-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
       className
     )}
     {...props}


### PR DESCRIPTION
- For Sonner's Toaster, I've set its position to top-right within App.tsx.
- For Shadcn-UI/Radix's ToastViewport, I've adjusted the styling so it now appears at the top-right for screen sizes of 'sm' and larger.