### PR TITLE
Fix 404 on subpath deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,20 @@ If npm reports vulnerabilities, you may attempt to automatically fix them with:
 npm audit fix
 ```
 
+## Deployment
+
+If you deploy this project under a subpath (for example on GitHub Pages),
+Vite needs to know the base URL so that asset links resolve correctly. The
+`vite.config.ts` file includes a `base` option set to `/clinical-case-compass/`.
+Adjust this value if your deployment path differs, then rebuild the project:
+
+```bash
+npm run build
+```
+
+After uploading the `dist/` directory to your hosting provider, the site should
+load without the blank 404-style page.
+
 ## Project Structure
 
 ```

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,9 @@ import { componentTagger } from "lovable-tagger";
 export default defineConfig(({ mode }) => {
   loadEnv(mode, process.cwd(), "");
   return {
+    // When deploying under a subpath (e.g. GitHub Pages),
+    // specify the base path so asset URLs resolve correctly.
+    base: "/clinical-case-compass/",
     envPrefix: "VITE_",
     server: {
       host: "::",


### PR DESCRIPTION
## Summary
- set `base` in `vite.config.ts` so the build works on subpath deployments
- document how to configure the base path for GitHub Pages or similar

## Testing
- `npm test` *(fails: toggleView is not defined, sidebar link highlight)*

------
https://chatgpt.com/codex/tasks/task_e_684818ec1b28832ebff240d7d522a3f8