### PR TITLE
Fix: Correct toast call to prevent React child error

### DIFF
--- a/src/lib/accessibility.ts
+++ b/src/lib/accessibility.ts
@@ -137,11 +137,7 @@ export class AccessibilityManager {
           if (event.error === 'not-allowed') {
             console.warn("Microphone access denied. Voice control disabled.");
             if (typeof toast === 'function') {
-              toast({
-                title: "Microphone Access Denied",
-                description: "Voice control is disabled because microphone access was denied. Please allow microphone permissions in your browser settings.",
-                variant: "destructive"
-              });
+              toast.error("Microphone Access Denied", { description: "Voice control is disabled because microphone access was denied. Please allow microphone permissions in your browser settings." });
             } else {
               alert("Microphone access denied. Voice control disabled. Please allow microphone permissions in your browser settings.");
             }


### PR DESCRIPTION
The application was encountering a "Minified React error #31" because an object (with keys {title, description, variant}) was being passed directly as an argument to the `toast()` function from the `sonner` library. This occurred in `src/lib/accessibility.ts` when attempting to display a message about microphone access denial.

This commit modifies the problematic `toast` call to use `toast.error(title, { description })` as per the `sonner` library's API. This ensures that React receives valid children (strings or React nodes) for rendering, resolving the error.

The microphone access denial message will now be displayed correctly as an error toast without crashing the application.