### PR TITLE
Remove unused motion import

### DIFF
--- a/src/pages/CreateCaseFlow.tsx
+++ b/src/pages/CreateCaseFlow.tsx
@@ -4,7 +4,6 @@ import { useForm, FormProvider } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { toast } from "sonner";
-import { motion } from "framer-motion";
 import { ChevronLeft, ChevronRight, Save, FileText, User, Stethoscope, BookOpen, SkipForward, AlertCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { FormContainer, StepMeta } from "@/features/cases/create/FormContainer";


### PR DESCRIPTION
## Summary
- delete unused `framer-motion` import from `CreateCaseFlow`

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any and others)*
- `npm test` *(fails: Tooltip must be used within TooltipProvider)*

------
https://chatgpt.com/codex/tasks/task_e_684c20fec0bc832ea3416afbd003d236