### PR TITLE
Update StepHeader style

### DIFF
--- a/src/features/cases/create/components/StepHeader.tsx
+++ b/src/features/cases/create/components/StepHeader.tsx
@@ -33,7 +33,7 @@ export const StepHeader = React.memo(function StepHeader({
           <div className="space-y-3">
             <h3 
               id={`${headerId}-title`}
-              className="flex items-center text-2xl font-bold text-white"
+              className="flex items-center text-lg font-semibold text-white"
             >
               <motion.div
                 initial={{ scale: 0.8, opacity: 0 }}


### PR DESCRIPTION
## Summary
- standardize StepHeader title styles with `text-lg font-semibold`

## Testing
- `npm test` *(fails: Tooltip must be used within TooltipProvider, expected spy to be called)*
- `npm run lint` *(fails: 5 errors, 18 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684c221959fc832ea521e2ebc2336b92