### PR TITLE
Fix muted text colors in create-case forms

### DIFF
--- a/src/features/cases/create/CaseInfoStep.tsx
+++ b/src/features/cases/create/CaseInfoStep.tsx
@@ -155,8 +155,8 @@ export const CaseInfoStep = memo(function CaseInfoStep<
                 message={fieldState.error?.message || "Title looks good!"}
                 id={fieldState.error ? "case-title-error" : "case-title-help"}
               />
-              <FormDescription 
-                className="mt-3 flex items-start gap-2 text-muted-foreground"
+              <FormDescription
+                className="mt-3 flex items-start gap-2 text-white/70"
                 id="case-title-help"
               >
                 <div className={cn(
@@ -207,8 +207,8 @@ export const CaseInfoStep = memo(function CaseInfoStep<
                 message={fieldState.error?.message}
                 id={fieldState.error ? "chief-complaint-error" : "chief-complaint-help"}
               />
-              <FormDescription 
-                className="mt-3 flex items-start gap-2 text-muted-foreground"
+              <FormDescription
+                className="mt-3 flex items-start gap-2 text-white/70"
                 id="chief-complaint-help"
               >
                 <div className={cn(
@@ -276,8 +276,8 @@ export const CaseInfoStep = memo(function CaseInfoStep<
                 message={fieldState.error?.message}
                 id={fieldState.error ? "specialty-error" : "specialty-help"}
               />
-              <FormDescription 
-                className="mt-3 flex items-start gap-2 text-muted-foreground"
+              <FormDescription
+                className="mt-3 flex items-start gap-2 text-white/70"
                 id="specialty-help"
               >
                 <div className="w-2 h-2 rounded-full bg-violet-400 mt-2 flex-shrink-0" aria-hidden="true"></div>

--- a/src/features/cases/create/FormNavigation.tsx
+++ b/src/features/cases/create/FormNavigation.tsx
@@ -110,7 +110,7 @@ export const FormNavigation: React.FC<FormNavigationProps> = ({
               <span className="font-medium" aria-live="polite">
                 Step {currentStep} of {totalSteps}
               </span>
-              <span className="text-muted-foreground" aria-live="polite">
+              <span className="text-white/70" aria-live="polite">
                 {currentStepLabel}
               </span>
             </div>
@@ -229,7 +229,7 @@ export const FormNavigation: React.FC<FormNavigationProps> = ({
         </div>
 
         {/* Keyboard Shortcuts Help */}
-        <div className="mt-2 text-xs text-muted-foreground flex items-center gap-2">
+        <div className="mt-2 text-xs text-white/70 flex items-center gap-2">
           <Keyboard className="h-3 w-3" aria-hidden="true" />
           <span>Keyboard shortcuts: Alt + ←/→ to navigate, Alt + S to save</span>
         </div>

--- a/src/features/cases/create/LearningPointsStep.tsx
+++ b/src/features/cases/create/LearningPointsStep.tsx
@@ -362,7 +362,7 @@ export const LearningPointsStep = memo(function LearningPointsStep<
                       {...field}
                     />
                   </FormControl>
-                  <FormDescription className="mt-3 flex items-start gap-2 text-muted-foreground">
+                  <FormDescription className="mt-3 flex items-start gap-2 text-white/70">
                     <div className={cn(
                       "w-2 h-2 rounded-full mt-2 flex-shrink-0",
                       fieldState.error ? "bg-red-400" : "bg-amber-400"
@@ -401,7 +401,7 @@ export const LearningPointsStep = memo(function LearningPointsStep<
                       {...field}
                     />
                   </FormControl>
-                  <FormDescription className="mt-3 flex items-start gap-2 text-muted-foreground">
+                  <FormDescription className="mt-3 flex items-start gap-2 text-white/70">
                     <div className="w-2 h-2 rounded-full bg-blue-400 mt-2 flex-shrink-0"></div>
                     Optional space for additional reflections or miscellaneous notes.
                   </FormDescription>
@@ -427,7 +427,7 @@ export const LearningPointsStep = memo(function LearningPointsStep<
               <TooltipProvider>
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <Info className="h-4 w-4 text-muted-foreground hover:text-foreground" />
+                    <Info className="h-4 w-4 text-white/70 hover:text-white" />
                   </TooltipTrigger>
                   <TooltipContent>
                     <p>Add links to educational resources like journal articles, guidelines, or videos</p>
@@ -491,7 +491,7 @@ export const LearningPointsStep = memo(function LearningPointsStep<
                 initial={{ opacity: 0, scale: 0.95 }}
                 animate={{ opacity: 1, scale: 1 }}
                 exit={{ opacity: 0, scale: 0.95 }}
-                className="text-center py-8 text-muted-foreground"
+                className="text-center py-8 text-white/70"
               >
                 <BookOpen className="h-8 w-8 mx-auto mb-3 text-gray-400" />
                 <p>No resources added yet. Click "Add Resource" to include educational materials.</p>

--- a/src/features/cases/create/PatientStep.tsx
+++ b/src/features/cases/create/PatientStep.tsx
@@ -80,7 +80,7 @@ export const PatientStep = memo(function PatientStep<
                 isValid={!fieldState.error}
                 message={fieldState.error?.message || "Patient name looks good!"}
               />
-              <FormDescription className="mt-3 flex items-start gap-2 text-muted-foreground">
+              <FormDescription className="mt-3 flex items-start gap-2 text-white/70">
                 <div className={cn(
                   "w-2 h-2 rounded-full mt-2 flex-shrink-0",
                   fieldState.error ? "bg-red-400" : "bg-emerald-400"
@@ -117,7 +117,7 @@ export const PatientStep = memo(function PatientStep<
                 isValid={!fieldState.error}
                 message={fieldState.error?.message}
               />
-              <FormDescription className="mt-3 flex items-start gap-2 text-muted-foreground">
+              <FormDescription className="mt-3 flex items-start gap-2 text-white/70">
                 <div className={cn(
                   "w-2 h-2 rounded-full mt-2 flex-shrink-0",
                   fieldState.error ? "bg-red-400" : "bg-rose-400"
@@ -157,7 +157,7 @@ export const PatientStep = memo(function PatientStep<
                   isValid={!fieldState.error}
                   message={fieldState.error?.message}
                 />
-                <FormDescription className="mt-3 flex items-start gap-2 text-muted-foreground">
+                <FormDescription className="mt-3 flex items-start gap-2 text-white/70">
                   <div className={cn(
                     "w-2 h-2 rounded-full mt-2 flex-shrink-0",
                     fieldState.error ? "bg-red-400" : "bg-violet-400"
@@ -199,7 +199,7 @@ export const PatientStep = memo(function PatientStep<
                   isValid={!fieldState.error}
                   message={fieldState.error?.message}
                 />
-                <FormDescription className="mt-3 flex items-start gap-2 text-muted-foreground">
+                <FormDescription className="mt-3 flex items-start gap-2 text-white/70">
                   <div className={cn(
                     "w-2 h-2 rounded-full mt-2 flex-shrink-0",
                     fieldState.error ? "bg-red-400" : "bg-blue-400"
@@ -237,7 +237,7 @@ export const PatientStep = memo(function PatientStep<
                 isValid={!fieldState.error}
                 message={fieldState.error?.message}
               />
-              <FormDescription className="mt-3 flex items-start gap-2 text-muted-foreground">
+              <FormDescription className="mt-3 flex items-start gap-2 text-white/70">
                 <div className={cn(
                   "w-2 h-2 rounded-full mt-2 flex-shrink-0",
                   fieldState.error ? "bg-red-400" : "bg-amber-400"

--- a/src/features/cases/create/components/StepHeader.tsx
+++ b/src/features/cases/create/components/StepHeader.tsx
@@ -49,10 +49,10 @@ export const StepHeader = React.memo(function StepHeader({
                 {title}
               </span>
             </h3>
-            <p 
-              id={`${headerId}-description`}
-              className="text-lg max-w-2xl leading-relaxed text-white/80"
-            >
+              <p
+                id={`${headerId}-description`}
+                className="text-lg max-w-2xl leading-relaxed text-white/70"
+              >
               {description}
             </p>
           </div>


### PR DESCRIPTION
## Summary
- harmonize helper text color by replacing `text-muted-foreground` and `text-white/80` with `text-white/70`
- update helper sections in CaseInfoStep, LearningPointsStep, PatientStep, FormNavigation, and StepHeader

## Testing
- `npm install`
- `npm test` *(fails: expected "spy" to be called)*

------
https://chatgpt.com/codex/tasks/task_e_684c221dbd88832eabaa5e899a56e447