### PR TITLE
Ensure consistent Select focus ring

### DIFF
--- a/src/features/cases/create/PatientStep.tsx
+++ b/src/features/cases/create/PatientStep.tsx
@@ -182,10 +182,12 @@ export const PatientStep = memo(function PatientStep<
               <FormItem>
                 <FormControl>
                   <Select onValueChange={field.onChange} defaultValue={field.value}>
-                    <SelectTrigger className={cn(
-                      "relative z-10 bg-transparent border-0 text-white placeholder:text-white/50 focus-visible:ring-0 focus-visible:ring-offset-0 text-base rounded-xl py-3 px-4 h-auto transition-all duration-200",
-                      fieldState.error && "border-red-400/50 focus-visible:ring-red-400/30"
-                    )}>
+                    <SelectTrigger
+                      className={cn(
+                        "relative z-10 bg-transparent border-0 text-white placeholder:text-white/50 text-base rounded-xl py-3 px-4 h-auto transition-all duration-200 focus-visible:ring-2 focus-visible:ring-blue-400/50 focus-visible:ring-offset-2",
+                        fieldState.error && "border-red-400/50 focus-visible:ring-red-400/30"
+                      )}
+                    >
                       <SelectValue placeholder="Select sex" />
                     </SelectTrigger>
                     <SelectContent className="bg-white/10 backdrop-blur-md rounded-xl border border-white/20 shadow-xl">


### PR DESCRIPTION
## Summary
- restore standard focus ring utilities on PatientStep Select trigger

## Testing
- `npm test` *(fails: Tooltip must be used within TooltipProvider)*

------
https://chatgpt.com/codex/tasks/task_e_684c23f3fdf0832ebfbcec5f1a9893dd