### PR TITLE
Fix compile errors and typography

### DIFF
--- a/src/features/cases/detail/ClinicalTextCard.tsx
+++ b/src/features/cases/detail/ClinicalTextCard.tsx
@@ -7,7 +7,7 @@ interface ClinicalTextCardProps {
   icon: React.ReactNode;
   title: string;
   content?: string;
-  layout?: "small" | "medium" | "large" | "hero" | "featured" | "tall";
+  layout?: "small" | "medium" | "large" | "hero" | "wide" | "tall";
   placeholder?: string;
 }
 

--- a/src/lib/typography.ts
+++ b/src/lib/typography.ts
@@ -36,6 +36,9 @@ export const typography = {
   // Component specific
   button: `text-sm font-medium`,
   link: `font-medium underline underline-offset-4`,
+
+  // Monospace code style
+  code: `font-mono text-sm text-white`,
   
   // Medical text styles
   dosage: `font-mono text-sm text-white/90`,

--- a/src/pages/CaseDetail.tsx
+++ b/src/pages/CaseDetail.tsx
@@ -32,7 +32,6 @@ import { LearningPointsCard } from "@/features/cases/detail/LearningPointsCard";
 import { ActionsCard } from "@/features/cases/detail/ActionsCard";
 
 import { FileText, Activity } from "lucide-react";
-import { commonStyles } from "@/lib/ui-styles";
 
 const CaseDetail = () => {
   const { id } = useParams<{ id: string }>();
@@ -95,7 +94,7 @@ const CaseDetail = () => {
   };
 
   return (
-    <div className={commonStyles.pageContainer}>
+    <div className="space-y-6">
       {/* Navigation */}
       <div className="mb-6">
         <Link

--- a/src/pages/CaseEdit.tsx
+++ b/src/pages/CaseEdit.tsx
@@ -13,7 +13,7 @@ import { useLocalStorage } from "@/hooks/use-local-storage";
 import { MedicalCase } from "@/types/case";
 import { useSupabaseCases } from "@/hooks/use-supabase-cases";
 import { CaseEditForm } from "@/features/cases/edit/CaseEditForm";
-import { layouts, typography } from "@/lib/design-system";
+import { layouts, typography } from "@/lib/ui-styles";
 import { colors } from "@/lib/design-tokens";
 
 // Define the form schema with optional fields

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -32,7 +32,7 @@ const NotFound = () => {
               <FileQuestion className="h-12 w-12 text-white/70" />
             </div>
             <h1 className={cn(responsiveType.display, "text-white mb-2")}>404</h1>
-            <h2 className={cn(responsiveType.h2, "text-white mb-2")}>Page Not Found</h2>
+            <h2 className={cn(typo.h2, "text-white mb-2")}>Page Not Found</h2>
             <p className={cn(typo.body, "text-white/70 leading-relaxed")}>
               The page you're looking for doesn't exist or has been moved.
             </p>


### PR DESCRIPTION
## Summary
- correct layout prop for `ClinicalTextCard`
- add `code` typography style
- adjust imports in `CaseEdit`
- remove unused `commonStyles` and simplify container in `CaseDetail`
- use correct typography on not found page

## Testing
- `npm run lint` *(fails: 54 errors, 20 warnings)*
- `npx tsc -p tsconfig.app.json`
- `npm test` *(fails to execute tests, enters watch mode)*

------
https://chatgpt.com/codex/tasks/task_e_684f44a7df1c832e8dd5fbe7da5c78e8