### PR TITLE
Fix: Resolve React.Children.only error and excessive re-renders on Ca…

### DIFF
--- a/src/features/cases/CaseCard.tsx
+++ b/src/features/cases/CaseCard.tsx
@@ -261,18 +261,18 @@ export const CaseCard: React.FC<CaseCardProps> = memo(
                             variant="outline"
                             className="group/btn relative bg-white/10 border-white/20 hover:bg-white/20 text-white"
                           >
-                            <Link to={`/cases/${medicalCase.id}`}>
-                              View Details
-                              <motion.div
-                                className="absolute right-0 top-1/2 -translate-y-1/2 text-white/60"
-                                animate={{
-                                  x: isHovered ? 4 : 0,
-                                  opacity: isHovered ? 1 : 0
-                                }}
-                                transition={{ duration: 0.2 }}
-                              >
-                                <ChevronRight className="h-4 w-4" />
-                              </motion.div>
+                            <Link to={`/cases/${medicalCase.id}`} className="flex items-center">
+                              <span className="flex items-center justify-center">
+                                View Details
+                                <motion.div
+                                  className="ml-1 absolute right-0 top-1/2 -translate-y-1/2 text-white/60"
+                                  style={{ x: isHovered ? 4 : 0, opacity: isHovered ? 1 : 0, position: 'relative', right: isHovered ? '-0.25rem' : '0rem' }}
+                                  animate={{ x: isHovered ? 4 : 0, opacity: isHovered ? 1 : 0 }}
+                                  transition={{ duration: 0.2 }}
+                                >
+                                  <ChevronRight className="h-4 w-4" />
+                                </motion.div>
+                              </span>
                             </Link>
                           </Button>
                         </TooltipTrigger>

--- a/src/features/cases/CaseListItem.tsx
+++ b/src/features/cases/CaseListItem.tsx
@@ -175,9 +175,11 @@ export const CaseListItem = memo<CaseListItemProps>(({ medicalCase, className, o
                           asChild
                           className="relative group/btn bg-white/10 hover:bg-white/20 text-white"
                         >
-                          <Link to={`/cases/${medicalCase.id}`}>
-                            <Eye className="h-4 w-4 transition-transform group-hover/btn:scale-110" />
-                            <span className="sr-only">View Case</span>
+                          <Link to={`/cases/${medicalCase.id}`} className="flex items-center">
+                            <span className="flex items-center">
+                              <Eye className="h-4 w-4 transition-transform group-hover/btn:scale-110" />
+                              <span className="sr-only">View Case</span>
+                            </span>
                           </Link>
                         </Button>
                       </TooltipTrigger>
@@ -196,9 +198,11 @@ export const CaseListItem = memo<CaseListItemProps>(({ medicalCase, className, o
                           asChild
                           className="relative group/btn bg-white/10 hover:bg-white/20 text-white"
                         >
-                          <Link to={`/cases/edit/${medicalCase.id}`}>
-                            <Edit className="h-4 w-4 transition-transform group-hover/btn:scale-110" />
-                            <span className="sr-only">Edit Case</span>
+                          <Link to={`/cases/edit/${medicalCase.id}`} className="flex items-center">
+                            <span className="flex items-center">
+                              <Edit className="h-4 w-4 transition-transform group-hover/btn:scale-110" />
+                              <span className="sr-only">Edit Case</span>
+                            </span>
                           </Link>
                         </Button>
                       </TooltipTrigger>


### PR DESCRIPTION
…ses page

This commit addresses two main issues:
1.  A `React.Children.only expected to receive a single React element child` error, which caused a general error boundary ("Something went wrong") to appear when viewing the Cases page. This was traced to components like `Button asChild` receiving multiple children from nested `Link` components.
    - Modified `CaseCard.tsx` and `CaseListItem.tsx` to wrap the children of `Link` components (when used inside `Button asChild`) with a single `<span>` element. This ensures the `Slot` mechanism used by `asChild` receives a valid single child.

2.  Excessive re-renders and re-initializations of the `useSupabaseCases` hook, identified by numerous console logs. This was primarily due to the `AuthContext` value changing on every render.
    - Optimized `AuthContext.tsx` by wrapping the context value object with `React.useMemo` and all callback functions (`signIn`, `signUp`, `signOut`, `updateProfile`) with `React.useCallback`. This stabilizes the context value and prevents unnecessary re-renders of consumers.

These changes should resolve the reported error and improve the performance and stability of the Cases page and components consuming the authentication context.