### PR TITLE
Fix: Allow 'unknown' for patient gender type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "clinical-case-compass",
-  "version": "0.5.0",
+  "name": "medica",
+  "version": "1.0.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "clinical-case-compass",
-      "version": "0.5.0",
+      "name": "medica",
+      "version": "1.0.0-beta.1",
       "dependencies": {
         "@hookform/resolvers": "^3.9.0",
         "@radix-ui/react-accordion": "^1.2.0",

--- a/src/types/case.ts
+++ b/src/types/case.ts
@@ -2,7 +2,7 @@ export interface Patient {
   id: string;
   name: string;
   age: number;
-  gender: "male" | "female" | "other";
+  gender: "male" | "female" | "other" | "unknown";
   medicalRecordNumber?: string;
 }
 


### PR DESCRIPTION
The `Patient` interface in `src/types/case.ts` previously defined the `gender` property as `"male" | "female" | "other"`. However, data transformation logic in `src/hooks/use-supabase-cases.ts` could assign 'unknown' to this property, leading to a TypeScript error (TS2322).

This commit updates the `Patient` interface to include 'unknown' as a valid gender option: `gender: "male" | "female" | "other" | "unknown";`

This resolves the type mismatch and aligns the type definition with its usage in the codebase. The change has been verified by the TypeScript compiler to ensure no new type errors are introduced.