### PR TITLE
Fix: Update Vite and Qodana configurations

### DIFF
--- a/qodana.yaml
+++ b/qodana.yaml
@@ -26,4 +26,4 @@ profile:
 #  - id: <plugin.id> #(plugin id can be found at https://plugins.jetbrains.com)
 
 #Specify Qodana linter for analysis (Applied in CI/CD pipeline)
-linter: jetbrains/qodana-<linter>:2024.2
+linter: jetbrains/qodana-js-community:2024.2

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
-import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
@@ -20,7 +19,6 @@ export default defineConfig(({ mode }) => {
     },
     plugins: [
       react(),
-      mode === 'development' && componentTagger(),
     ].filter(Boolean),
     resolve: {
       alias: {


### PR DESCRIPTION
- Removed unused `componentTagger` Vite plugin.
- Specified `js-community` as the Qodana linter.