### PR TITLE
Refactor: Extract repetitive JSX from App.tsx into ProtectedRouteLayout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,7 @@
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.0.1",
         "vite": "^5.4.1",
-        "vitest": "^3.1.4"
+        "vitest": "^3.2.3"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -3500,6 +3500,15 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
@@ -3562,6 +3571,12 @@
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.6",
@@ -3974,13 +3989,14 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.1.4.tgz",
-      "integrity": "sha512-xkD/ljeliyaClDYqHPNCiJ0plY5YIcM0OlRiZizLhlPmpXWpxnGMyTZXOHFhFeG7w9P5PBeL4IdtJ/HeQwTbQA==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.3.tgz",
+      "integrity": "sha512-W2RH2TPWVHA1o7UmaFKISPvdicFJH+mjykctJFoAkUw+SPTJTGjUNdKscFBrqM7IPnCVu6zihtKYa7TkZS1dkQ==",
       "dev": true,
       "dependencies": {
-        "@vitest/spy": "3.1.4",
-        "@vitest/utils": "3.1.4",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.3",
+        "@vitest/utils": "3.2.3",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -3989,12 +4005,12 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.1.4.tgz",
-      "integrity": "sha512-8IJ3CvwtSw/EFXqWFL8aCMu+YyYXG2WUSrQbViOZkWTKTVicVwZ/YiEZDSqD00kX+v/+W+OnxhNWoeVKorHygA==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.3.tgz",
+      "integrity": "sha512-cP6fIun+Zx8he4rbWvi+Oya6goKQDZK+Yq4hhlggwQBbrlOQ4qtZ+G4nxB6ZnzI9lyIb+JnvyiJnPC2AGbKSPA==",
       "dev": true,
       "dependencies": {
-        "@vitest/spy": "3.1.4",
+        "@vitest/spy": "3.2.3",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -4003,7 +4019,7 @@
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^5.0.0 || ^6.0.0"
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -4015,9 +4031,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.4.tgz",
-      "integrity": "sha512-cqv9H9GvAEoTaoq+cYqUTCGscUjKqlJZC7PRwY5FMySVj5J+xOm1KQcCiYHJOEzOKRUhLH4R2pTwvFlWCEScsg==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.3.tgz",
+      "integrity": "sha512-yFglXGkr9hW/yEXngO+IKMhP0jxyFw2/qys/CK4fFUZnSltD+MU7dVYGrH8rvPcK/O6feXQA+EU33gjaBBbAng==",
       "dev": true,
       "dependencies": {
         "tinyrainbow": "^2.0.0"
@@ -4027,25 +4043,26 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.1.4.tgz",
-      "integrity": "sha512-djTeF1/vt985I/wpKVFBMWUlk/I7mb5hmD5oP8K9ACRmVXgKTae3TUOtXAEBfslNKPzUQvnKhNd34nnRSYgLNQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.3.tgz",
+      "integrity": "sha512-83HWYisT3IpMaU9LN+VN+/nLHVBCSIUKJzGxC5RWUOsK1h3USg7ojL+UXQR3b4o4UBIWCYdD2fxuzM7PQQ1u8w==",
       "dev": true,
       "dependencies": {
-        "@vitest/utils": "3.1.4",
-        "pathe": "^2.0.3"
+        "@vitest/utils": "3.2.3",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.1.4.tgz",
-      "integrity": "sha512-JPHf68DvuO7vilmvwdPr9TS0SuuIzHvxeaCkxYcCD4jTk67XwL45ZhEHFKIuCm8CYstgI6LZ4XbwD6ANrwMpFg==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.3.tgz",
+      "integrity": "sha512-9gIVWx2+tysDqUmmM1L0hwadyumqssOL1r8KJipwLx5JVYyxvVRfxvMq7DaWbZZsCqZnu/dZedaZQh4iYTtneA==",
       "dev": true,
       "dependencies": {
-        "@vitest/pretty-format": "3.1.4",
+        "@vitest/pretty-format": "3.2.3",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -4054,24 +4071,24 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.1.4.tgz",
-      "integrity": "sha512-Xg1bXhu+vtPXIodYN369M86K8shGLouNjoVI78g8iAq2rFoHFdajNvJJ5A/9bPMFcfQqdaCpOgWKEoMQg/s0Yg==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.3.tgz",
+      "integrity": "sha512-JHu9Wl+7bf6FEejTCREy+DmgWe+rQKbK+y32C/k5f4TBIAlijhJbRBIRIOCEpVevgRsCQR2iHRUH2/qKVM/plw==",
       "dev": true,
       "dependencies": {
-        "tinyspy": "^3.0.2"
+        "tinyspy": "^4.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.1.4.tgz",
-      "integrity": "sha512-yriMuO1cfFhmiGc8ataN51+9ooHRuURdfAZfwFd3usWynjzpLslZdYnRegTv32qdgtJTsj15FoeZe2g15fY1gg==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.3.tgz",
+      "integrity": "sha512-4zFBCU5Pf+4Z6v+rwnZ1HU1yzOKKvDkMXZrymE2PBlbjKJRlrOxbvpfPSvJTGRIwGoahaOGvp+kbCoxifhzJ1Q==",
       "dev": true,
       "dependencies": {
-        "@vitest/pretty-format": "3.1.4",
+        "@vitest/pretty-format": "3.2.3",
         "loupe": "^3.1.3",
         "tinyrainbow": "^2.0.0"
       },
@@ -8253,6 +8270,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.0.0.tgz",
+      "integrity": "sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true
+    },
     "node_modules/sucrase": {
       "version": "3.35.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
@@ -8469,9 +8504,9 @@
       }
     },
     "node_modules/tinyspy": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
-      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.3.tgz",
+      "integrity": "sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==",
       "dev": true,
       "engines": {
         "node": ">=14.0.0"
@@ -8806,16 +8841,16 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.1.4.tgz",
-      "integrity": "sha512-6enNwYnpyDo4hEgytbmc6mYWHXDHYEn0D1/rw4Q+tnHUGtKTJsn8T1YkX6Q18wI5LCrS8CTYlBaiCqxOy2kvUA==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.3.tgz",
+      "integrity": "sha512-gc8aAifGuDIpZHrPjuHyP4dpQmYXqWw7D1GmDnWeNWP654UEXzVfQ5IHPSK5HaHkwB/+p1atpYpSdw/2kOv8iQ==",
       "dev": true,
       "dependencies": {
         "cac": "^6.7.14",
-        "debug": "^4.4.0",
+        "debug": "^4.4.1",
         "es-module-lexer": "^1.7.0",
         "pathe": "^2.0.3",
-        "vite": "^5.0.0 || ^6.0.0"
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
       },
       "bin": {
         "vite-node": "vite-node.mjs"
@@ -8828,31 +8863,33 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.1.4.tgz",
-      "integrity": "sha512-Ta56rT7uWxCSJXlBtKgIlApJnT6e6IGmTYxYcmxjJ4ujuZDI59GUQgVDObXXJujOmPDBYXHK1qmaGtneu6TNIQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.3.tgz",
+      "integrity": "sha512-E6U2ZFXe3N/t4f5BwUaVCKRLHqUpk1CBWeMh78UT4VaTPH/2dyvH6ALl29JTovEPu9dVKr/K/J4PkXgrMbw4Ww==",
       "dev": true,
       "dependencies": {
-        "@vitest/expect": "3.1.4",
-        "@vitest/mocker": "3.1.4",
-        "@vitest/pretty-format": "^3.1.4",
-        "@vitest/runner": "3.1.4",
-        "@vitest/snapshot": "3.1.4",
-        "@vitest/spy": "3.1.4",
-        "@vitest/utils": "3.1.4",
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.3",
+        "@vitest/mocker": "3.2.3",
+        "@vitest/pretty-format": "^3.2.3",
+        "@vitest/runner": "3.2.3",
+        "@vitest/snapshot": "3.2.3",
+        "@vitest/spy": "3.2.3",
+        "@vitest/utils": "3.2.3",
         "chai": "^5.2.0",
-        "debug": "^4.4.0",
+        "debug": "^4.4.1",
         "expect-type": "^1.2.1",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
         "std-env": "^3.9.0",
         "tinybench": "^2.9.0",
         "tinyexec": "^0.3.2",
-        "tinyglobby": "^0.2.13",
-        "tinypool": "^1.0.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.0",
         "tinyrainbow": "^2.0.0",
-        "vite": "^5.0.0 || ^6.0.0",
-        "vite-node": "3.1.4",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.3",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -8868,8 +8905,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.1.4",
-        "@vitest/ui": "3.1.4",
+        "@vitest/browser": "3.2.3",
+        "@vitest/ui": "3.2.3",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -8895,6 +8932,18 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,6 @@
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
     "vite": "^5.4.1",
-    "vitest": "^3.1.4"
+    "vitest": "^3.2.3"
   }
 }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -7,9 +7,7 @@ import { AnimatePresence } from "framer-motion"; // Added AnimatePresence
 import { AuthProvider, useAuth } from "./AuthContext";
 import { ThemeProvider } from "@/lib/design-system";
 import { ErrorBoundary } from "@/components/error/ErrorBoundary";
-import { EnhancedAppLayout } from "@/features/navigation/components/EnhancedAppLayout";
-import { PrivateRoute } from "@/features/auth/PrivateRoute";
-import { OfflineBanner } from "@/components/ui/OfflineBanner";
+import { ProtectedRouteLayout } from "@/features/navigation";
 import LoadingScreen from "@/components/ui/loading-screen";
 
 // Pages
@@ -45,9 +43,9 @@ const queryClient = new QueryClient({
 });
 
 const AppContent = () => {
-  const { session, loading, isOfflineMode } = useAuth();
+  const { session, loading } = useAuth();
 
-  console.log("[App] Auth state:", { session: !!session, loading, isOfflineMode });
+  console.log("[App] Auth state:", { session: !!session, loading });
 
   if (loading) {
     return <LoadingScreen />;
@@ -65,7 +63,7 @@ const AppContent = () => {
 // and `Routes`. The `key` on `Routes` ensures `AnimatePresence` detects route changes.
 const AppRoutes = () => {
   const location = useLocation();
-  const { session, isOfflineMode } = useAuth(); // Used to determine route elements.
+  const { session } = useAuth(); // Used to determine route elements.
 
   return (
     // AnimatePresence enables the animation of components that are mounted or unmounted.
@@ -83,74 +81,56 @@ const AppRoutes = () => {
         <Route
           path="/dashboard"
           element={
-            <PrivateRoute>
-              <EnhancedAppLayout>
-                {isOfflineMode && <div className="mb-4"><OfflineBanner /></div>}
-                <Dashboard />
-              </EnhancedAppLayout>
-            </PrivateRoute>
+            <ProtectedRouteLayout>
+              <Dashboard />
+            </ProtectedRouteLayout>
           }
         />
         <Route
           path="/cases"
           element={
-            <PrivateRoute>
-              <EnhancedAppLayout>
-                {isOfflineMode && <div className="mb-4"><OfflineBanner /></div>}
-                <ErrorBoundary fallback={
-                  <div className="p-8 text-center">
-                    <h2 className="text-xl font-semibold text-white mb-2">Cases Page Error</h2>
-                    <p className="text-white/70">There was an error loading the cases page.</p>
-                  </div>
-                }>
-                  <Cases />
-                </ErrorBoundary>
-              </EnhancedAppLayout>
-            </PrivateRoute>
+            <ProtectedRouteLayout>
+              <ErrorBoundary fallback={
+                <div className="p-8 text-center">
+                  <h2 className="text-xl font-semibold text-white mb-2">Cases Page Error</h2>
+                  <p className="text-white/70">There was an error loading the cases page.</p>
+                </div>
+              }>
+                <Cases />
+              </ErrorBoundary>
+            </ProtectedRouteLayout>
           }
         />
         <Route
           path="/cases/:id"
           element={
-            <PrivateRoute>
-              <EnhancedAppLayout>
-                {isOfflineMode && <div className="mb-4"><OfflineBanner /></div>}
-                <CaseDetail />
-              </EnhancedAppLayout>
-            </PrivateRoute>
+            <ProtectedRouteLayout>
+              <CaseDetail />
+            </ProtectedRouteLayout>
           }
         />
         <Route
           path="/cases/edit/:id"
           element={
-            <PrivateRoute>
-              <EnhancedAppLayout>
-                {isOfflineMode && <div className="mb-4"><OfflineBanner /></div>}
-                <CaseEdit />
-              </EnhancedAppLayout>
-            </PrivateRoute>
+            <ProtectedRouteLayout>
+              <CaseEdit />
+            </ProtectedRouteLayout>
           }
         />
         <Route
           path="/cases/new"
           element={
-            <PrivateRoute>
-              <EnhancedAppLayout>
-                {isOfflineMode && <div className="mb-4"><OfflineBanner /></div>}
-                <CreateCaseFlow />
-              </EnhancedAppLayout>
-            </PrivateRoute>
+            <ProtectedRouteLayout>
+              <CreateCaseFlow />
+            </ProtectedRouteLayout>
           }
         />
         <Route
           path="/account"
           element={
-            <PrivateRoute>
-              <EnhancedAppLayout>
-                {isOfflineMode && <div className="mb-4"><OfflineBanner /></div>}
-                <Account />
-              </EnhancedAppLayout>
-            </PrivateRoute>
+            <ProtectedRouteLayout>
+              <Account />
+            </ProtectedRouteLayout>
           }
         />
         <Route path="/" element={session ? <Navigate to="/dashboard" replace /> : <Navigate to="/landing" replace />} />
@@ -158,9 +138,9 @@ const AppRoutes = () => {
           path="*"
           element={
             session ? (
-              <EnhancedAppLayout>
+              <ProtectedRouteLayout>
                 <NotFound />
-              </EnhancedAppLayout>
+              </ProtectedRouteLayout>
             ) : (
               <Navigate to="/landing" replace />
             )

--- a/src/app/AuthContext.tsx
+++ b/src/app/AuthContext.tsx
@@ -6,7 +6,7 @@ import { useToast } from "@/hooks/use-toast";
 import { authReducer, initialAuthState, type AuthState, type AuthAction } from "@/lib/reducers/authReducer";
 import type { UserMetadata } from "@/types/auth";
 
-type AuthContextType = {
+export type AuthContextType = {
   session: Session | null;
   user: User | null;
   loading: boolean;
@@ -17,7 +17,7 @@ type AuthContextType = {
   updateProfile: (data: UserMetadata) => Promise<void>;
 };
 
-const AuthContext = createContext<AuthContextType | undefined>(undefined);
+export const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [state, dispatch] = useReducer(authReducer, initialAuthState);

--- a/src/features/navigation/components/ProtectedRouteLayout.test.tsx
+++ b/src/features/navigation/components/ProtectedRouteLayout.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import ProtectedRouteLayout from './ProtectedRouteLayout';
+import { AuthContext, AuthContextType } from '@/app/AuthContext';
+
+// Mock dependencies
+vi.mock('@/features/auth/PrivateRoute', () => ({
+  PrivateRoute: ({ children }: { children: React.ReactNode }) => <div data-testid="private-route">{children}</div>,
+}));
+
+vi.mock('@/features/navigation/components/EnhancedAppLayout', () => ({
+  EnhancedAppLayout: ({ children }: { children: React.ReactNode }) => <div data-testid="enhanced-app-layout">{children}</div>,
+}));
+
+vi.mock('@/components/ui/OfflineBanner', () => ({
+  OfflineBanner: () => <div data-testid="offline-banner">Offline Banner</div>,
+}));
+
+const mockAuthContext = (isOfflineMode: boolean, session: boolean = true): AuthContextType => ({
+  session: session ? { user: { id: 'test-user' } } : null, // Provide a minimal session object
+  loading: false,
+  isOfflineMode,
+  signInWithGithub: vi.fn(),
+  signOut: vi.fn(),
+  user: null, // Add other necessary fields from AuthContextType if your component uses them
+  error: null,
+  setError: vi.fn(),
+  login: vi.fn(),
+  signup: vi.fn(),
+  sendPasswordResetEmail: vi.fn(),
+  updatePassword: vi.fn(),
+});
+
+describe('ProtectedRouteLayout', () => {
+  it('renders children within PrivateRoute and EnhancedAppLayout', () => {
+    render(
+      <MemoryRouter>
+        <AuthContext.Provider value={mockAuthContext(false)}>
+          <ProtectedRouteLayout>
+            <div>Test Child</div>
+          </ProtectedRouteLayout>
+        </AuthContext.Provider>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('private-route')).toBeInTheDocument();
+    expect(screen.getByTestId('enhanced-app-layout')).toBeInTheDocument();
+    expect(screen.getByText('Test Child')).toBeInTheDocument();
+  });
+
+  it('displays OfflineBanner when isOfflineMode is true', () => {
+    render(
+      <MemoryRouter>
+        <AuthContext.Provider value={mockAuthContext(true)}>
+          <ProtectedRouteLayout>
+            <div>Test Child</div>
+          </ProtectedRouteLayout>
+        </AuthContext.Provider>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('offline-banner')).toBeInTheDocument();
+  });
+
+  it('does not display OfflineBanner when isOfflineMode is false', () => {
+    render(
+      <MemoryRouter>
+        <AuthContext.Provider value={mockAuthContext(false)}>
+          <ProtectedRouteLayout>
+            <div>Test Child</div>
+          </ProtectedRouteLayout>
+        </AuthContext.Provider>
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByTestId('offline-banner')).not.toBeInTheDocument();
+  });
+});

--- a/src/features/navigation/components/ProtectedRouteLayout.tsx
+++ b/src/features/navigation/components/ProtectedRouteLayout.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { EnhancedAppLayout } from "@/features/navigation/components/EnhancedAppLayout";
+import { PrivateRoute } from "@/features/auth/PrivateRoute";
+import { OfflineBanner } from "@/components/ui/OfflineBanner";
+import { useAuth } from "@/app/AuthContext"; // Import useAuth
+
+interface ProtectedRouteLayoutProps {
+  children: React.ReactNode;
+}
+
+const ProtectedRouteLayout: React.FC<ProtectedRouteLayoutProps> = ({ children }) => {
+  const { isOfflineMode } = useAuth(); // Get isOfflineMode from useAuth
+
+  return (
+    <PrivateRoute>
+      <EnhancedAppLayout>
+        {isOfflineMode && (
+          <div className="mb-4">
+            <OfflineBanner />
+          </div>
+        )}
+        {children}
+      </EnhancedAppLayout>
+    </PrivateRoute>
+  );
+};
+
+export default ProtectedRouteLayout;

--- a/src/features/navigation/index.ts
+++ b/src/features/navigation/index.ts
@@ -4,3 +4,4 @@
 export { EnhancedAppLayout } from './components/EnhancedAppLayout';
 export { default as EnhancedNavbar } from '../../components/navigation/EnhancedNavbar';
 export { default as Breadcrumbs } from '../../components/navigation/Breadcrumbs';
+export * from "./components/ProtectedRouteLayout";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,12 @@ export default defineConfig(({ mode }) => {
   const isGitHubPages = env.VITE_DEPLOY_TARGET === 'github-pages';
   
   return {
+    // Vitest configuration
+    test: {
+      globals: true,
+      environment: 'jsdom',
+      setupFiles: './src/setupTests.ts', // if you have a setup file
+    },
     // Set base path only for GitHub Pages, use root for all other deployments
     base: isGitHubPages ? "/medica/" : "/",
     envPrefix: "VITE_",


### PR DESCRIPTION
This commit introduces a new component, `ProtectedRouteLayout`, to encapsulate the common structure used for protected routes in `App.tsx`.

The `ProtectedRouteLayout` component includes:
- `PrivateRoute` for authentication checking.
- `EnhancedAppLayout` for the consistent page layout.
- Conditional rendering of `OfflineBanner` based on `isOfflineMode` from `AuthContext`.

This refactoring significantly reduces JSX repetition in `App.tsx` for the following routes:
- `/dashboard`
- `/cases`
- `/cases/:id`
- `/cases/edit/:id`
- `/cases/new`
- `/account`

I have added unit tests for `ProtectedRouteLayout` to ensure it renders correctly and handles the offline mode display.