### PR TITLE
Refactor: Modularize design-system.ts and consolidate styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ function AnimatedContent() {
 
 ### Theme Switching
 ```typescript
-import { useTheme } from '@/lib/design-system';
+import { useTheme } from '@/lib/styles/theme';
 
 function ThemeSwitcher() {
   const { currentTheme, setTheme, getThemeNames } = useTheme();

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -5,7 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/sonner";
 import { AnimatePresence } from "framer-motion"; // Added AnimatePresence
 import { AuthProvider, useAuth } from "./AuthContext";
-import { ThemeProvider } from "@/lib/design-system";
+import { ThemeProvider } from "@/lib/styles/theme";
 import { ErrorBoundary } from "@/components/error/ErrorBoundary";
 import { ProtectedRouteLayout } from "@/features/navigation";
 import LoadingScreen from "@/components/ui/loading-screen";

--- a/src/components/backgrounds/UnifiedBackground.tsx
+++ b/src/components/backgrounds/UnifiedBackground.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { motion, useScroll, useTransform, useSpring } from "framer-motion";
-import { useTheme } from "@/lib/design-system";
+import { useTheme } from "@/lib/styles/theme";
 import { cn } from "@/lib/utils";
 import { prefersReducedMotion } from "@/lib/motion";
 import { animatedIconsConfig, particleConfig, hexagonConfig } from "@/lib/background-config";

--- a/src/components/examples/DesignSystemExample.tsx
+++ b/src/components/examples/DesignSystemExample.tsx
@@ -16,20 +16,16 @@ import {
   BookOpen
 } from 'lucide-react';
 
+import { useTheme, themes } from '@/lib/styles/theme';
+import { animations } from '@/lib/styles/animations';
 import { 
-  useTheme,
-  animations,
   getComponentStyles,
   getBentoStyles,
   getGlassmorphicStyles,
-  getAnimationVariants,
-  backgroundConfig,
-  button,
-  card,
-  input,
-  bento,
-  themes
-} from '@/lib/design-system';
+  getAnimationVariants
+} from '@/lib/styles/utils';
+import { button, card, input, bento } from '@/lib/styles/components';
+import { backgroundConfig } from '@/lib/design-system'; // backgroundConfig remains
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';

--- a/src/components/examples/UnifiedComponentSystemExample.tsx
+++ b/src/components/examples/UnifiedComponentSystemExample.tsx
@@ -15,10 +15,10 @@ import {
 import { 
   getComponentStyles, 
   getBentoStyles, 
-  getGlassmorphicStyles,
-  buttonVariants,
-  card 
-} from '@/lib/design-system';
+  getGlassmorphicStyles
+} from '@/lib/styles/utils';
+import { buttonVariants } from '@/lib/styles/common';
+import { card } from '@/lib/styles/components';
 
 export function UnifiedComponentSystemExample() {
   return (

--- a/src/components/ui/bento-card.tsx
+++ b/src/components/ui/bento-card.tsx
@@ -1,10 +1,11 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
-import { cardVariants as unifiedCardVariants, bentoGrid, componentSizes } from "@/lib/component-system";
+import { bento as newBentoStyles, card as newCardStyles } from "@/lib/styles/components"; // Updated imports
 
 interface BentoCardProps extends React.HTMLAttributes<HTMLDivElement> {
-  layout?: keyof typeof bentoGrid.layouts;
-  variant?: keyof typeof unifiedCardVariants;
+  layout?: keyof typeof newBentoStyles.card.span; // Or map from old layout values if needed
+  size?: keyof typeof newBentoStyles.card.size; // Explicit size prop
+  variant?: keyof typeof newCardStyles.variant; // Use new card variants
   icon?: React.ReactNode;
   title?: string;
   subtitle?: string;
@@ -14,7 +15,8 @@ interface BentoCardProps extends React.HTMLAttributes<HTMLDivElement> {
 const BentoCard = React.forwardRef<HTMLDivElement, BentoCardProps>(
   ({ 
     className, 
-    layout = "medium", 
+    layout = "medium", // Corresponds to a span key
+    size = "medium",   // Corresponds to a size key
     variant = "default", 
     icon, 
     title, 
@@ -22,17 +24,21 @@ const BentoCard = React.forwardRef<HTMLDivElement, BentoCardProps>(
     children, 
     ...props 
   }, ref) => {
-    const layoutClasses = bentoGrid.layouts[layout];
-    const variantClasses = unifiedCardVariants[variant];
+    // Assuming layout prop maps to a span key and size prop maps to a size key
+    const spanClass = newBentoStyles.card.span[layout as keyof typeof newBentoStyles.card.span] || newBentoStyles.card.span.medium;
+    const sizeClass = newBentoStyles.card.size[size as keyof typeof newBentoStyles.card.size] || newBentoStyles.card.size.medium;
+    const cardStyleClasses = newCardStyles.variant[variant] || newCardStyles.variant.default;
 
     return (
       <div
         ref={ref}
         className={cn(
-          "flex flex-col",
-          layoutClasses,
-          variantClasses,
-          componentSizes.card.md,
+          "flex flex-col", // Base flex layout for card content
+          newCardStyles.base, // Base styles from new card system (includes rounding, base glassmorphism)
+          cardStyleClasses,   // Variant styles from new card system
+          spanClass,          // Bento span class
+          sizeClass,          // Bento size class
+          newCardStyles.padding.lg, // Use padding from new card system (p-6)
           className
         )}
         {...props}
@@ -41,7 +47,7 @@ const BentoCard = React.forwardRef<HTMLDivElement, BentoCardProps>(
         {(icon || title || subtitle) && (
           <div className="flex items-start gap-3 mb-4">
             {icon && (
-              <div className={cn("flex-shrink-0", componentSizes.icon.lg)}>
+              <div className={cn("flex-shrink-0", "h-6 w-6")}> {/* Replaced componentSizes.icon.lg */}
                 {icon}
               </div>
             )}

--- a/src/components/ui/bento-container.tsx
+++ b/src/components/ui/bento-container.tsx
@@ -1,20 +1,21 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
-import { bentoGrid } from "@/lib/component-system";
+import { bento as newBentoStyles } from "@/lib/styles/components"; // Updated import
 
 interface BentoContainerProps extends React.HTMLAttributes<HTMLDivElement> {
-  layout?: keyof typeof bentoGrid.container;
+  gap?: keyof typeof newBentoStyles.container.gap; // Changed prop from layout to gap
   children: React.ReactNode;
 }
 
 const BentoContainer = React.forwardRef<HTMLDivElement, BentoContainerProps>(
-  ({ className, layout = "default", children, ...props }, ref) => {
-    const layoutClasses = bentoGrid.container[layout];
+  ({ className, gap = "default", children, ...props }, ref) => { // Changed prop from layout to gap
+    // Map old layout values to new gap values if necessary, or just use new gap directly
+    const gapClass = newBentoStyles.container.gap[gap];
 
     return (
       <div
         ref={ref}
-        className={cn(layoutClasses, className)}
+        className={cn(newBentoStyles.container.base, gapClass, className)} // Apply new base and gap
         {...props}
       >
         {children}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { Loader2 } from "lucide-react"
 import { motion, Variants } from "framer-motion" // Added motion
 
 import { cn } from "@/lib/utils"
-import { buttonVariants as unifiedButtonVariants } from "@/lib/design-system"
+import { buttonVariants as unifiedButtonVariants } from "@/lib/styles/common"
 import { typography } from "@/lib/typography"
 import {
   getMotionVariants,

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { motion } from "framer-motion" // Added motion
 import { cn } from "@/lib/utils"
-import { cardVariants as unifiedCardVariants, componentSizes } from "@/lib/component-system"
+import { card as newCardStyles } from "@/lib/styles/components" // Updated import
 import {
   getMotionVariants,
   subtleCardInteraction,
@@ -11,7 +11,7 @@ import {
 const Card = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement> & {
-    variant?: keyof typeof unifiedCardVariants
+    variant?: keyof typeof newCardStyles.variant // Updated to use newCardStyles
     // Consumers can pass standard motion props like 'whileHover', 'variants' etc. to override defaults if needed.
   }
 >(({ className, variant = "default", ...props }, ref) => {
@@ -25,8 +25,8 @@ const Card = React.forwardRef<
     <motion.div
       ref={ref}
       className={cn(
-        "rounded-xl", // Base styles from card.tsx
-        unifiedCardVariants[variant], // Theme styles from component-system (includes base shadow, bg, etc.)
+        newCardStyles.base, // Use base style from new system
+        newCardStyles.variant[variant], // Use variant style from new system
         className
       )}
       // Apply the subtle interaction variants for hover and focus states.
@@ -47,7 +47,7 @@ const CardHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex flex-col space-y-1.5", componentSizes.card.md, className)}
+    className={cn("flex flex-col space-y-1.5", newCardStyles.padding.lg, className)} // Use new padding
     {...props}
   />
 ))
@@ -84,7 +84,7 @@ const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("pt-0", componentSizes.card.md, className)} {...props} />
+  <div ref={ref} className={cn("pt-0", newCardStyles.padding.lg, className)} {...props} /> // Use new padding
 ))
 CardContent.displayName = "CardContent"
 
@@ -94,7 +94,7 @@ const CardFooter = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex items-center pt-0", componentSizes.card.md, className)}
+    className={cn("flex items-center pt-0", newCardStyles.padding.lg, className)} // Use new padding
     {...props}
   />
 ))

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -4,7 +4,7 @@ import { Check } from "lucide-react"
 import { motion } from "framer-motion" // Added motion
 
 import { cn } from "@/lib/utils"
-import { focusRing } from "@/lib/ui-styles"
+import { focusRing } from "@/lib/styles/common" // Updated import
 import {
   getMotionVariants,
   subtleCheckboxHover,

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -5,7 +5,7 @@ import { Search } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 import { Dialog, DialogContent } from "@/components/ui/dialog"
-import { glass } from "@/lib/ui-styles"
+import { glass } from "@/lib/styles/common" // Updated import
 
 const Command = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive>,

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -3,7 +3,7 @@ import * as DialogPrimitive from "@radix-ui/react-dialog"
 import { X } from "lucide-react"
 
 import { cn } from "@/lib/utils"
-import { glass } from "@/lib/ui-styles"
+import { glass } from "@/lib/styles/common" // Updated import
 
 const Dialog = DialogPrimitive.Root
 

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { motion } from "framer-motion" // Added motion
 import { cn } from "@/lib/utils"
-import { inputVariants as unifiedInputVariants, componentSizes } from "@/lib/component-system"
+import { input as newInputStyles } from "@/lib/styles/components" // Updated import
 import {
   getMotionVariants,
   subtleInputInteraction,
@@ -10,11 +10,11 @@ import {
 
 export interface InputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
-  variant?: keyof typeof unifiedInputVariants
+  // variant prop is removed as new system uses a single base style for input + sizes
 }
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, variant = "default", ...props }, ref) => {
+  ({ className, type, ...props }, ref) => { // variant prop removed from destructuring
     // Get the appropriate animation variants based on user's reduced motion preference
     const appliedVariants = getMotionVariants(subtleInputInteraction, reducedMotionInputInteraction);
 
@@ -23,12 +23,8 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <motion.input
         type={type}
         className={cn(
-          "flex w-full rounded-lg", // Base styles
-          // Note: We are removing unifiedInputVariants[variant] if it heavily styles border/shadow that motion will handle
-          // Or ensure motion variants override. For now, let's assume motion variants will take precedence for border/shadow.
-          // If not, we might need to adjust the className to remove conflicting styles on focus.
-          unifiedInputVariants[variant],
-          componentSizes.input.md,
+          newInputStyles.base,    // Use base style from new system
+          newInputStyles.size.md, // Use size style from new system
           className
         )}
         ref={ref}

--- a/src/components/ui/settings-card.tsx
+++ b/src/components/ui/settings-card.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
-import { glass } from '@/lib/ui-styles';
+import { glass } from '@/lib/styles/common'; // Updated import
 
 interface SettingsCardProps {
   title: string;

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { X } from "lucide-react"
 
 import { cn } from "@/lib/utils"
-import { glass, focusRing } from "@/lib/ui-styles"
+import { focusRing, glass } from "@/lib/styles/common" // Updated import
 
 const ToastProvider = ToastPrimitives.Provider
 

--- a/src/features/auth/components/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm.tsx
@@ -8,7 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { loginSchema, type LoginFormData } from "@/features/auth/authSchemas";
-import { useTheme } from "@/lib/design-system";
+import { useTheme } from "@/lib/styles/theme";
 
 interface LoginFormProps {
   onLoginSubmit: (data: LoginFormData) => Promise<void>;

--- a/src/features/auth/components/SignupForm.tsx
+++ b/src/features/auth/components/SignupForm.tsx
@@ -8,7 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { signupSchema, type SignupFormData } from "@/features/auth/authSchemas";
-import { useTheme } from "@/lib/design-system";
+import { useTheme } from "@/lib/styles/theme";
 
 interface SignupFormProps {
   onSignupSubmit: (data: SignupFormData) => Promise<void>;

--- a/src/features/landing/components/CtaSection.tsx
+++ b/src/features/landing/components/CtaSection.tsx
@@ -3,7 +3,8 @@ import React from 'react';
 import { motion } from 'framer-motion';
 import { NavLink } from 'react-router-dom';
 import { cn } from '@/lib/utils';
-import { buttonVariants, typography } from '@/lib/design-system';
+import { buttonVariants } from '@/lib/styles/common';
+import { typography } from '@/lib/design-system';
 import { ArrowRight } from 'lucide-react';
 
 const CtaSection = () => {

--- a/src/lib/DESIGN_SYSTEM_GUIDE.md
+++ b/src/lib/DESIGN_SYSTEM_GUIDE.md
@@ -7,15 +7,10 @@ The Clinical Case Compass unified design system provides a single source of trut
 ## 🚀 Quick Start
 
 ```typescript
-import { 
-  useTheme,
-  getComponentStyles,
-  getBentoStyles,
-  animations,
-  button,
-  card,
-  input
-} from '@/lib/design-system';
+import { useTheme } from '@/lib/styles/theme';
+import { getComponentStyles, getBentoStyles } from '@/lib/styles/utils';
+import { animations } from '@/lib/styles/animations';
+import { button, card, input } from '@/lib/styles/components';
 ```
 
 ## 🎨 Theme System
@@ -23,7 +18,7 @@ import {
 ### Using Theme Context
 
 ```typescript
-import { useTheme } from '@/lib/design-system';
+import { useTheme } from '@/lib/styles/theme';
 
 const MyComponent = () => {
   const { currentTheme, setTheme, availableThemes } = useTheme();
@@ -50,7 +45,7 @@ const MyComponent = () => {
 ### Buttons
 
 ```typescript
-import { getComponentStyles } from '@/lib/design-system';
+import { getComponentStyles } from '@/lib/styles/utils';
 
 // Method 1: Using utility function
 <Button className={getComponentStyles('button', 'primary', 'md')}>
@@ -149,7 +144,7 @@ const cardClass = getBentoStyles('card', 'medium', 'default');
 
 ```typescript
 import { motion } from 'framer-motion';
-import { animations } from '@/lib/design-system';
+import { animations } from '@/lib/styles/animations';
 
 <motion.div
   variants={animations.fadeIn}
@@ -186,7 +181,7 @@ import { animations } from '@/lib/design-system';
 ### Accessibility Support
 
 ```typescript
-import { getAnimationVariants } from '@/lib/design-system';
+import { getAnimationVariants } from '@/lib/styles/utils';
 
 // Automatically respects user's reduced motion preference
 <motion.div variants={getAnimationVariants('fadeIn')}>
@@ -225,7 +220,8 @@ const cardShadow = shadows.glass; // 0 8px 32px rgba(0, 0, 0, 0.1)
 ### Glassmorphic Styles
 
 ```typescript
-import { getGlassmorphicStyles, useTheme } from '@/lib/design-system';
+import { getGlassmorphicStyles } from '@/lib/styles/utils';
+import { useTheme } from '@/lib/styles/theme';
 
 const MyComponent = () => {
   const { currentTheme } = useTheme();
@@ -257,7 +253,7 @@ import { buttonVariants, cardBase } from '@/lib/ui-styles';
 
 ```typescript
 // New way
-import { getComponentStyles } from '@/lib/design-system';
+import { getComponentStyles } from '@/lib/styles/utils';
 
 <Button className={getComponentStyles('button', 'primary', 'md')}>Button</Button>
 <Card className={getComponentStyles('card', 'default')}>Content</Card>

--- a/src/lib/design-system.ts
+++ b/src/lib/design-system.ts
@@ -1,538 +1,21 @@
-import React from "react";
-import { createContext, useContext, useState, useEffect } from "react";
-import { motion, Variants, Transition, useMotionValue, useTransform, useSpring } from "framer-motion";
+// Framer motion elements that might still be used directly or for other components not refactored.
+import { motion, useMotionValue, useTransform, useSpring } from "framer-motion";
+// Lucide icons - keep if they are used by other components not part of this refactor
 import { Stethoscope, Pill } from "lucide-react";
+
+// Import design tokens and configurations that are globally used or re-exported
 import { typography } from "./typography";
-// Import the source of truth for glassmorphicEntrance
-import { glassmorphicEntrance as libGlassmorphicEntrance } from "./motion";
 import { typographyTokens, colors, spacing, borderRadius, shadows } from "./design-tokens";
 import { backgroundConfig } from "./background-config";
 
-// ────────────────────────────────────────────────────────────────────────────────
-// UNIFIED COMPONENT STYLES (from ui-styles.ts)
-// ────────────────────────────────────────────────────────────────────────────────
+// Re-export elements from the new style modules
+export * from "./styles/common";
+export * from "./styles/theme";
+export * from "./styles/components";
+export * from "./styles/animations";
+export * from "./styles/utils";
 
-/** Enhanced focus ring for interactive elements */
-export const focusRing = "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400/50 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent";
-
-/** Disabled state styling */
-export const disabledState = "disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed";
-
-/** Enhanced glassmorphic effect */
-export const glassmorphic = `backdrop-blur-md border-white/20 transition-all duration-200 ease-out`;
-
-/** Enhanced glassmorphic backgrounds with better depth */
-export const glass = {
-  subtle: `${glassmorphic} bg-white/10 shadow-sm`,
-  elevated: `${glassmorphic} bg-white/15 shadow-md border-white/25`,
-  overlay: `backdrop-blur-xl border-white/25 bg-white/10 shadow-lg`,
-  card: `${glassmorphic} bg-white/10 rounded-xl shadow-sm border`,
-  cardElevated: `${glassmorphic} bg-white/15 rounded-xl shadow-md border`
-} as const;
-
-/** Base styles for buttons */
-export const buttonBase = `
-  inline-flex items-center justify-center whitespace-nowrap rounded-xl 
-  text-sm font-medium transition-all duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400/50 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent ${disabledState}
-  h-10 px-4
-`.trim();
-
-/** Button variants using the design system */
-export const buttonVariants = {
-  primary: `${buttonBase} bg-white/15 backdrop-blur-md text-white border border-white/20 hover:bg-white/25 shadow-md`,
-  secondary: `${buttonBase} bg-white/10 backdrop-blur-md text-white/70 border border-white/20 hover:bg-white/20`,
-  outline: `${buttonBase} bg-transparent text-white border border-white/20 hover:bg-white/10`,
-  ghost: `${buttonBase} bg-transparent text-white/70 hover:bg-white/10`,
-  destructive: `${buttonBase} bg-red-500/10 text-red-300 border border-red-400/30 hover:bg-red-500/20`,
-  success: `${buttonBase} bg-green-500/10 text-green-300 border border-green-400/30 hover:bg-green-500/20`,
-  warning: `${buttonBase} bg-yellow-500/20 text-yellow-300 border border-yellow-400/30 hover:bg-yellow-500/20`,
-  error: `${buttonBase} bg-red-500/20 text-red-300 border border-red-400/30 hover:bg-red-500/20`,
-  info: `${buttonBase} bg-blue-500/20 text-blue-300 border border-blue-400/30 hover:bg-blue-500/20`,
-  medical: `${buttonBase} bg-sky-500/20 text-sky-300 border border-sky-400/30 hover:bg-sky-500/20`,
-  critical: `${buttonBase} bg-red-600 text-white border border-red-500 hover:bg-red-700 font-bold`,
-} as const;
-
-// ────────────────────────────────────────────────────────────────────────────────
-// THEME SYSTEM
-// ────────────────────────────────────────────────────────────────────────────────
-
-/** Theme Configuration Interface */
-export interface ThemeConfig {
-  name: string;
-  description: string;
-  colors: {
-    primary: string;
-    secondary: string;
-    accent: string;
-    background: string;
-    surface: string;
-    text: string;
-    textSecondary: string;
-    border: string;
-    glass: {
-      background: string;
-      border: string;
-      shadow: string;
-      backdrop: string;
-    };
-    gradient: {
-      primary: string;
-      secondary: string;
-      accent: string;
-    };
-    status: {
-      success: string;
-      warning: string;
-      error: string;
-      info: string;
-    };
-  };
-  effects: {
-    blur: string;
-    shadow: string;
-    border: string;
-    glow: string;
-  };
-}
-
-/** Predefined Theme Configurations */
-export const themes: Record<string, ThemeConfig> = {
-  medical: {
-    name: "Medical Blue",
-    description: "Professional medical theme with clinical blue tones",
-    colors: {
-      primary: "#0ea5e9",
-      secondary: "#0284c7",
-      accent: "#3b82f6",
-      background: "linear-gradient(135deg, #0c4a6e 0%, #0369a1 50%, #0284c7 100%)",
-      surface: "#f8fafc",
-      text: "#ffffff",
-      textSecondary: "rgba(255, 255, 255, 0.8)",
-      border: "rgba(255, 255, 255, 0.2)",
-      glass: {
-        background: "rgba(255, 255, 255, 0.1)",
-        border: "rgba(255, 255, 255, 0.2)",
-        shadow: "0 8px 32px rgba(0, 0, 0, 0.1)",
-        backdrop: "blur(20px)",
-      },
-      gradient: {
-        primary: "linear-gradient(135deg, #0ea5e9 0%, #3b82f6 100%)",
-        secondary: "linear-gradient(135deg, #0284c7 0%, #0c4a6e 100%)",
-        accent: "linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%)",
-      },
-      status: {
-        success: "#10b981",
-        warning: "#f59e0b",
-        error: "#ef4444",
-        info: "#3b82f6",
-      },
-    },
-    effects: {
-      blur: "blur(20px)",
-      shadow: "0 8px 32px rgba(0, 0, 0, 0.1)",
-      border: "1px solid rgba(255, 255, 255, 0.2)",
-      glow: "0 0 20px rgba(59, 130, 246, 0.3)",
-    },
-  },
-  emerald: {
-    name: "Emerald Medical",
-    description: "Fresh and modern medical theme with emerald accents",
-    colors: {
-      primary: "#10b981",
-      secondary: "#059669",
-      accent: "#34d399",
-      background: "linear-gradient(135deg, #064e3b 0%, #065f46 50%, #047857 100%)",
-      surface: "#f0fdf4",
-      text: "#ffffff",
-      textSecondary: "rgba(255, 255, 255, 0.8)",
-      border: "rgba(255, 255, 255, 0.2)",
-      glass: {
-        background: "rgba(255, 255, 255, 0.1)",
-        border: "rgba(255, 255, 255, 0.2)",
-        shadow: "0 8px 32px rgba(0, 0, 0, 0.1)",
-        backdrop: "blur(20px)",
-      },
-      gradient: {
-        primary: "linear-gradient(135deg, #10b981 0%, #34d399 100%)",
-        secondary: "linear-gradient(135deg, #059669 0%, #047857 100%)",
-        accent: "linear-gradient(135deg, #34d399 0%, #6ee7b7 100%)",
-      },
-      status: {
-        success: "#10b981",
-        warning: "#f59e0b",
-        error: "#ef4444",
-        info: "#3b82f6",
-      },
-    },
-    effects: {
-      blur: "blur(20px)",
-      shadow: "0 8px 32px rgba(0, 0, 0, 0.1)",
-      border: "1px solid rgba(255, 255, 255, 0.2)",
-      glow: "0 0 20px rgba(16, 185, 129, 0.3)",
-    },
-  },
-  purple: {
-    name: "Purple Medical",
-    description: "Sophisticated medical theme with purple and violet tones",
-    colors: {
-      primary: "#8b5cf6",
-      secondary: "#7c3aed",
-      accent: "#a78bfa",
-      background: "linear-gradient(135deg, #4c1d95 0%, #5b21b6 50%, #6d28d9 100%)",
-      surface: "#faf5ff",
-      text: "#ffffff",
-      textSecondary: "rgba(255, 255, 255, 0.8)",
-      border: "rgba(255, 255, 255, 0.2)",
-      glass: {
-        background: "rgba(255, 255, 255, 0.1)",
-        border: "rgba(255, 255, 255, 0.2)",
-        shadow: "0 8px 32px rgba(0, 0, 0, 0.1)",
-        backdrop: "blur(20px)",
-      },
-      gradient: {
-        primary: "linear-gradient(135deg, #8b5cf6 0%, #a78bfa 100%)",
-        secondary: "linear-gradient(135deg, #7c3aed 0%, #6d28d9 100%)",
-        accent: "linear-gradient(135deg, #a78bfa 0%, #c4b5fd 100%)",
-      },
-      status: {
-        success: "#10b981",
-        warning: "#f59e0b",
-        error: "#ef4444",
-        info: "#3b82f6",
-      },
-    },
-    effects: {
-      blur: "blur(20px)",
-      shadow: "0 8px 32px rgba(0, 0, 0, 0.1)",
-      border: "1px solid rgba(255, 255, 255, 0.2)",
-      glow: "0 0 20px rgba(139, 92, 246, 0.3)",
-    },
-  },
-};
-
-// ────────────────────────────────────────────────────────────────────────────────
-// COMPONENT DESIGN TOKENS
-// ────────────────────────────────────────────────────────────────────────────────
-
-/** Button System */
-export const button = {
-  base: `inline-flex items-center justify-center whitespace-nowrap rounded-lg text-sm font-medium 
-         transition-all duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 
-         focus-visible:ring-blue-400/50 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent 
-         disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed`,
-  size: {
-    default: 'h-10 px-4 text-sm',
-    sm: 'h-8 px-3 text-xs',
-    md: 'h-10 px-4 text-sm',
-    lg: 'h-12 px-6 text-base',
-  },
-  variant: {
-    primary: 'bg-white/15 backdrop-blur-md text-white border border-white/20 hover:bg-white/25 shadow-md',
-    secondary: 'bg-white/10 backdrop-blur-md text-white/70 border border-white/20 hover:bg-white/20',
-    outline: 'bg-transparent text-white border border-white/20 hover:bg-white/10',
-    ghost: 'bg-transparent text-white/70 hover:bg-white/10',
-    destructive: 'bg-red-500/10 text-red-300 border border-red-400/30 hover:bg-red-500/20',
-  },
-};
-
-/** Input System */
-export const input = {
-  base: `flex w-full rounded-lg text-sm text-white placeholder:text-white/60 
-         bg-white/10 backdrop-blur-md border border-white/20 
-         focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400/50 
-         focus-visible:ring-offset-2 focus-visible:ring-offset-transparent 
-         disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed 
-         hover:bg-white/20 hover:border-white/30 transition-all duration-200 ease-out`,
-  size: {
-    default: 'h-10 px-4 text-sm',
-    sm: 'h-8 px-3 text-xs',
-    md: 'h-10 px-4 text-sm',
-    lg: 'h-12 px-4 text-base',
-  },
-};
-
-/** Card System */
-export const card = {
-  base: `backdrop-blur-md border border-white/20 transition-all duration-200 ease-out rounded-xl`,
-  variant: {
-    default: 'bg-white/10 shadow-sm',
-    elevated: 'bg-white/15 shadow-md border-white/25',
-    interactive: 'bg-white/15 shadow-md hover:bg-white/25 hover:shadow-xl hover:shadow-white/10 cursor-pointer hover:scale-[1.01]',
-    featured: 'bg-white/15 ring-1 ring-white/30 shadow-lg shadow-white/5',
-    compact: 'bg-white/10 shadow-sm',
-  },
-  padding: {
-    sm: 'p-3',
-    md: 'p-4',
-    lg: 'p-6',
-  },
-};
-
-/** Bento Grid System */
-export const bento = {
-  container: {
-    base: 'grid auto-rows-min grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-6',
-    gap: {
-      tight: 'gap-3',
-      default: 'gap-4',
-      loose: 'gap-6',
-    },
-  },
-  card: {
-    size: {
-      compact: 'min-h-[160px]',
-      default: 'min-h-[200px]',
-      medium: 'min-h-[240px]',
-      large: 'min-h-[280px]',
-      hero: 'min-h-[320px]',
-      tall: 'min-h-[380px]',
-    },
-    span: {
-      small: 'col-span-1 sm:col-span-2',
-      medium: 'col-span-2 lg:col-span-3',
-      large: 'col-span-2 md:col-span-3 lg:col-span-4',
-      hero: 'col-span-2 md:col-span-3 lg:col-span-4',
-      wide: 'col-span-full lg:col-span-6',
-      tall: 'col-span-2 lg:col-span-3',
-    },
-  },
-};
-
-// ────────────────────────────────────────────────────────────────────────────────
-// ANIMATION SYSTEM
-// ────────────────────────────────────────────────────────────────────────────────
-
-/** Core Animation Variants */
-export const animations = {
-  // Entrance animations
-  fadeIn: {
-    hidden: { opacity: 0, y: 20, scale: 0.95 },
-    visible: { opacity: 1, y: 0, scale: 1, transition: { duration: 0.4, ease: [0.23, 1, 0.32, 1] } },
-    exit: { opacity: 0, y: -20, scale: 0.95, transition: { duration: 0.3, ease: "easeInOut" } },
-  } as Variants,
-  
-  // Glassmorphic entrance (now using the single source of truth)
-  glassmorphicEntrance: libGlassmorphicEntrance,
-
-  // Staggered animations
-  staggeredContainer: {
-    hidden: { opacity: 0 },
-    visible: { opacity: 1, transition: { staggerChildren: 0.1, delayChildren: 0.2 } },
-  } as Variants,
-
-  staggeredItem: {
-    hidden: { opacity: 0, y: 20, scale: 0.95 },
-    visible: { opacity: 1, y: 0, scale: 1, transition: { duration: 0.5, ease: [0.23, 1, 0.32, 1] } },
-  } as Variants,
-
-  // Hover effects
-  glassyHover: {
-    initial: { scale: 1, rotateX: 0, rotateY: 0, filter: "brightness(1)" },
-    hover: { scale: 1.02, rotateX: 2, rotateY: 2, filter: "brightness(1.1)", transition: { duration: 0.3, ease: "easeOut" } },
-    tap: { scale: 0.98, transition: { duration: 0.1 } },
-  } as Variants,
-
-  // Floating animation
-  floating: {
-    initial: { y: 0 },
-    animate: { y: [-5, 5, -5], transition: { duration: 4, repeat: Infinity, ease: "easeInOut" } },
-  } as Variants,
-
-  // Pulse glow
-  pulseGlow: {
-    initial: { boxShadow: "0 0 0 0 rgba(255, 255, 255, 0.1)" },
-    animate: {
-      boxShadow: [
-        "0 0 0 0 rgba(255, 255, 255, 0.1)",
-        "0 0 0 10px rgba(255, 255, 255, 0.05)",
-        "0 0 0 0 rgba(255, 255, 255, 0.1)",
-      ],
-      transition: { duration: 2, repeat: Infinity, ease: "easeInOut" },
-    },
-  } as Variants,
-} as const;
-
-/** Transition Presets */
-export const transitions = {
-  fast: { duration: 0.15, ease: "easeOut" } as Transition,
-  default: { duration: 0.2, ease: "easeOut" } as Transition,
-  slow: { duration: 0.3, ease: "easeOut" } as Transition,
-  spring: { type: "spring", stiffness: 100, damping: 20 } as Transition,
-  optimized: { duration: 0.3, ease: [0.23, 1, 0.32, 1], type: "spring", stiffness: 100, damping: 20 } as Transition,
-} as const;
-
-// ────────────────────────────────────────────────────────────────────────────────
-// THEME PROVIDER & CONTEXT
-// ────────────────────────────────────────────────────────────────────────────────
-
-interface ThemeContextType {
-  currentTheme: ThemeConfig;
-  setTheme: (themeName: string) => void;
-  availableThemes: string[];
-  getThemeNames: () => Array<{ name: string; description: string }>;
-}
-
-const ThemeContext = React.createContext<ThemeContextType | undefined>(undefined);
-
-export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [currentThemeName, setCurrentThemeName] = useState<string>("medical");
-  const currentTheme = themes[currentThemeName] || themes.medical;
-
-  const setTheme = (themeName: string) => {
-    if (themes[themeName]) {
-      setCurrentThemeName(themeName);
-      localStorage.setItem("selected-theme", themeName);
-    }
-  };
-
-  const availableThemes = Object.keys(themes);
-  const getThemeNames = () => Object.values(themes).map(theme => ({ name: theme.name, description: theme.description }));
-
-  // Load saved theme on mount
-  useEffect(() => {
-    const savedTheme = localStorage.getItem("selected-theme");
-    if (savedTheme && themes[savedTheme]) {
-      setCurrentThemeName(savedTheme);
-    }
-  }, []);
-
-  // Apply theme to document
-  useEffect(() => {
-    const root = document.documentElement;
-    root.classList.add('dark');
-    
-    // Apply CSS custom properties
-    Object.entries({
-      "--theme-primary": currentTheme.colors.primary,
-      "--theme-secondary": currentTheme.colors.secondary,
-      "--theme-accent": currentTheme.colors.accent,
-      "--theme-background": currentTheme.colors.background,
-      "--theme-surface": currentTheme.colors.surface,
-      "--theme-text": currentTheme.colors.text,
-      "--theme-text-secondary": currentTheme.colors.textSecondary,
-      "--theme-border": currentTheme.colors.border,
-      "--theme-glass-bg": currentTheme.colors.glass.background,
-      "--theme-glass-border": currentTheme.colors.glass.border,
-      "--theme-glass-shadow": currentTheme.colors.glass.shadow,
-      "--theme-glass-backdrop": currentTheme.colors.glass.backdrop,
-      "--theme-blur": currentTheme.effects.blur,
-      "--theme-shadow": currentTheme.effects.shadow,
-      "--theme-border-width": currentTheme.effects.border,
-      "--theme-glow": currentTheme.effects.glow,
-    }).forEach(([property, value]) => {
-      root.style.setProperty(property, value);
-    });
-    
-    document.body.style.background = currentTheme.colors.background;
-    return () => root.classList.remove('dark');
-  }, [currentTheme]);
-
-  return React.createElement(
-    ThemeContext.Provider,
-    { value: { currentTheme, setTheme, availableThemes, getThemeNames } },
-    children
-  );
-};
-
-export const useTheme = () => {
-  const context = useContext(ThemeContext);
-  if (!context) {
-    throw new Error("useTheme must be used within a ThemeProvider");
-  }
-  return context;
-};
-
-// ────────────────────────────────────────────────────────────────────────────────
-// UTILITY FUNCTIONS
-// ────────────────────────────────────────────────────────────────────────────────
-
-/** Get glassmorphic styles */
-export const getGlassmorphicStyles = (theme: ThemeConfig, variant: "default" | "elevated" | "subtle" | "light" = "default") => {
-  const baseStyles = {
-    backgroundColor: theme.colors.glass.background,
-    backdropFilter: theme.colors.glass.backdrop,
-    border: theme.colors.glass.border,
-    boxShadow: theme.colors.glass.shadow,
-  };
-
-  switch (variant) {
-    case "elevated":
-      return {
-        ...baseStyles,
-        backgroundColor: theme.colors.glass.background.replace("0.1", "0.15"),
-        boxShadow: "0 12px 40px rgba(0, 0, 0, 0.15)",
-        border: theme.colors.glass.border.replace("0.2", "0.3"),
-      };
-    case "subtle":
-      return {
-        ...baseStyles,
-        backgroundColor: theme.colors.glass.background.replace("0.1", "0.05"),
-        boxShadow: "0 4px 16px rgba(0, 0, 0, 0.05)",
-        border: theme.colors.glass.border.replace("0.2", "0.1"),
-      };
-    case "light":
-        return {
-          ...baseStyles,
-          backgroundColor: theme.colors.glass.background.replace("0.1", "0.12"),
-          boxShadow: "0 6px 20px rgba(0, 0, 0, 0.08)",
-          border: theme.colors.glass.border.replace("0.2", "0.25"),
-        };
-    default:
-      return baseStyles;
-  }
-};
-
-/** Get component styles */
-export const getComponentStyles = (component: 'button' | 'input' | 'card', variant?: string, size?: string) => {
-  const componentMap = { button, input, card };
-  const comp = componentMap[component];
-  if (!comp) return '';
-  
-  let styles = comp.base;
-  if (variant && 'variant' in comp && comp.variant) {
-    const variantStyle = comp.variant[variant as keyof typeof comp.variant];
-    if (variantStyle) styles += ` ${variantStyle}`;
-  }
-  if (size && 'size' in comp && comp.size) {
-    const sizeStyle = comp.size[size as keyof typeof comp.size];
-    if (sizeStyle) styles += ` ${sizeStyle}`;
-  }
-  
-  return styles.trim();
-};
-
-/** Get bento grid styles */
-export const getBentoStyles = (type: 'container' | 'card', variant?: string, size?: string) => {
-  if (type === 'container') {
-    const gap = variant || 'default';
-    return `${bento.container.base} ${bento.container.gap[gap as keyof typeof bento.container.gap]}`;
-  }
-  
-  if (type === 'card') {
-    const cardSize = size || 'default';
-    const cardSpan = variant || 'medium';
-    return `${bento.card.size[cardSize as keyof typeof bento.card.size]} ${bento.card.span[cardSpan as keyof typeof bento.card.span]}`;
-  }
-  
-  return '';
-};
-
-/** Check for reduced motion preference */
-export const prefersReducedMotion = () => {
-  if (typeof window === "undefined") return false;
-  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-};
-
-/** Get appropriate animation variants */
-export const getAnimationVariants = (animationName: keyof typeof animations) => {
-  if (prefersReducedMotion()) {
-    return { initial: { opacity: 0 }, visible: { opacity: 1 }, exit: { opacity: 0 } };
-  }
-  return animations[animationName];
-};
-
-// Only export the imported tokens ONCE, no duplicate exports!
-
+// Re-export core design tokens and configurations
 export {
   typographyTokens,
   typography,
@@ -541,27 +24,59 @@ export {
   borderRadius,
   shadows,
   backgroundConfig,
+  // Potentially re-export framer-motion and lucide-react if they were part of the original public API
+  motion,
+  useMotionValue,
+  useTransform,
+  useSpring,
+  Stethoscope,
+  Pill
 };
 
-/** Default export of the complete design system */
+// The default export should now compose from the new modules and existing tokens/configs.
+// This provides a single point of access to the design system, maintaining the original API.
+import * as commonStyles from "./styles/common";
+import * as themeSystem from "./styles/theme";
+import * as componentStyles from "./styles/components";
+import * as animationSystem from "./styles/animations";
+import * as utils from "./styles/utils";
+
 export default {
+  // Tokens and configs
   typographyTokens,
   typography,
   colors,
   spacing,
   borderRadius,
   shadows,
-  button,
-  input,
-  card,
-  bento,
-  animations,
-  transitions,
   backgroundConfig,
-  themes,
-  getGlassmorphicStyles,
-  getComponentStyles,
-  getBentoStyles,
-  getAnimationVariants,
-  prefersReducedMotion,
+
+  // Styles from common.ts
+  ...commonStyles,
+
+  // Theme system from theme.ts (excluding ThemeProvider and useTheme if they are meant to be used via named exports)
+  // Typically themes object is what you'd include in a default export.
+  themes: themeSystem.themes,
+
+  // Component styles from components.ts
+  ...componentStyles,
+
+  // Animations and transitions from animations.ts
+  ...animationSystem,
+
+  // Utilities from utils.ts
+  ...utils,
+
+  // It's debatable whether ThemeProvider and useTheme should be part of the default export.
+  // Named exports are generally preferred for them.
+  // ThemeProvider: themeSystem.ThemeProvider, // Example if you choose to include
+  // useTheme: themeSystem.useTheme, // Example if you choose to include
+
+  // Framer motion and lucide icons can also be part of the default export if desired
+  motion,
+  useMotionValue,
+  useTransform,
+  useSpring,
+  Stethoscope,
+  Pill
 };

--- a/src/lib/styles/animations.ts
+++ b/src/lib/styles/animations.ts
@@ -1,0 +1,66 @@
+import { Variants, Transition } from "framer-motion";
+// Import the source of truth for glassmorphicEntrance
+import { glassmorphicEntrance as libGlassmorphicEntrance } from "../motion"; // Adjusted path
+
+// ────────────────────────────────────────────────────────────────────────────────
+// ANIMATION SYSTEM
+// ────────────────────────────────────────────────────────────────────────────────
+
+/** Core Animation Variants */
+export const animations = {
+  // Entrance animations
+  fadeIn: {
+    hidden: { opacity: 0, y: 20, scale: 0.95 },
+    visible: { opacity: 1, y: 0, scale: 1, transition: { duration: 0.4, ease: [0.23, 1, 0.32, 1] } },
+    exit: { opacity: 0, y: -20, scale: 0.95, transition: { duration: 0.3, ease: "easeInOut" } },
+  } as Variants,
+
+  // Glassmorphic entrance (now using the single source of truth)
+  glassmorphicEntrance: libGlassmorphicEntrance,
+
+  // Staggered animations
+  staggeredContainer: {
+    hidden: { opacity: 0 },
+    visible: { opacity: 1, transition: { staggerChildren: 0.1, delayChildren: 0.2 } },
+  } as Variants,
+
+  staggeredItem: {
+    hidden: { opacity: 0, y: 20, scale: 0.95 },
+    visible: { opacity: 1, y: 0, scale: 1, transition: { duration: 0.5, ease: [0.23, 1, 0.32, 1] } },
+  } as Variants,
+
+  // Hover effects
+  glassyHover: {
+    initial: { scale: 1, rotateX: 0, rotateY: 0, filter: "brightness(1)" },
+    hover: { scale: 1.02, rotateX: 2, rotateY: 2, filter: "brightness(1.1)", transition: { duration: 0.3, ease: "easeOut" } },
+    tap: { scale: 0.98, transition: { duration: 0.1 } },
+  } as Variants,
+
+  // Floating animation
+  floating: {
+    initial: { y: 0 },
+    animate: { y: [-5, 5, -5], transition: { duration: 4, repeat: Infinity, ease: "easeInOut" } },
+  } as Variants,
+
+  // Pulse glow
+  pulseGlow: {
+    initial: { boxShadow: "0 0 0 0 rgba(255, 255, 255, 0.1)" },
+    animate: {
+      boxShadow: [
+        "0 0 0 0 rgba(255, 255, 255, 0.1)",
+        "0 0 0 10px rgba(255, 255, 255, 0.05)",
+        "0 0 0 0 rgba(255, 255, 255, 0.1)",
+      ],
+      transition: { duration: 2, repeat: Infinity, ease: "easeInOut" },
+    },
+  } as Variants,
+} as const;
+
+/** Transition Presets */
+export const transitions = {
+  fast: { duration: 0.15, ease: "easeOut" } as Transition,
+  default: { duration: 0.2, ease: "easeOut" } as Transition,
+  slow: { duration: 0.3, ease: "easeOut" } as Transition,
+  spring: { type: "spring", stiffness: 100, damping: 20 } as Transition,
+  optimized: { duration: 0.3, ease: [0.23, 1, 0.32, 1], type: "spring", stiffness: 100, damping: 20 } as Transition,
+} as const;

--- a/src/lib/styles/common.ts
+++ b/src/lib/styles/common.ts
@@ -1,0 +1,42 @@
+import React from "react"; // Though not directly used by these variables, it's good practice if other common utils are added.
+// It's also possible some of these string constants could evolve into components.
+
+/** Enhanced focus ring for interactive elements */
+export const focusRing = "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400/50 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent";
+
+/** Disabled state styling */
+export const disabledState = "disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed";
+
+/** Enhanced glassmorphic effect */
+export const glassmorphic = `backdrop-blur-md border-white/20 transition-all duration-200 ease-out`;
+
+/** Enhanced glassmorphic backgrounds with better depth */
+export const glass = {
+  subtle: `${glassmorphic} bg-white/10 shadow-sm`,
+  elevated: `${glassmorphic} bg-white/15 shadow-md border-white/25`,
+  overlay: `backdrop-blur-xl border-white/25 bg-white/10 shadow-lg`,
+  card: `${glassmorphic} bg-white/10 rounded-xl shadow-sm border`,
+  cardElevated: `${glassmorphic} bg-white/15 rounded-xl shadow-md border`
+} as const;
+
+/** Base styles for buttons */
+export const buttonBase = `
+  inline-flex items-center justify-center whitespace-nowrap rounded-xl
+  text-sm font-medium transition-all duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400/50 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent ${disabledState}
+  h-10 px-4
+`.trim();
+
+/** Button variants using the design system */
+export const buttonVariants = {
+  primary: `${buttonBase} bg-white/15 backdrop-blur-md text-white border border-white/20 hover:bg-white/25 shadow-md`,
+  secondary: `${buttonBase} bg-white/10 backdrop-blur-md text-white/70 border border-white/20 hover:bg-white/20`,
+  outline: `${buttonBase} bg-transparent text-white border border-white/20 hover:bg-white/10`,
+  ghost: `${buttonBase} bg-transparent text-white/70 hover:bg-white/10`,
+  destructive: `${buttonBase} bg-red-500/10 text-red-300 border border-red-400/30 hover:bg-red-500/20`,
+  success: `${buttonBase} bg-green-500/10 text-green-300 border border-green-400/30 hover:bg-green-500/20`,
+  warning: `${buttonBase} bg-yellow-500/20 text-yellow-300 border border-yellow-400/30 hover:bg-yellow-500/20`,
+  error: `${buttonBase} bg-red-500/20 text-red-300 border border-red-400/30 hover:bg-red-500/20`,
+  info: `${buttonBase} bg-blue-500/20 text-blue-300 border border-blue-400/30 hover:bg-blue-500/20`,
+  medical: `${buttonBase} bg-sky-500/20 text-sky-300 border border-sky-400/30 hover:bg-sky-500/20`,
+  critical: `${buttonBase} bg-red-600 text-white border border-red-500 hover:bg-red-700 font-bold`,
+} as const;

--- a/src/lib/styles/components.ts
+++ b/src/lib/styles/components.ts
@@ -1,0 +1,87 @@
+// ────────────────────────────────────────────────────────────────────────────────
+// COMPONENT DESIGN TOKENS
+// ────────────────────────────────────────────────────────────────────────────────
+
+/** Button System */
+export const button = {
+  base: `inline-flex items-center justify-center whitespace-nowrap rounded-lg text-sm font-medium
+         transition-all duration-200 ease-out focus-visible:outline-none focus-visible:ring-2
+         focus-visible:ring-blue-400/50 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent
+         disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed`,
+  size: {
+    default: 'h-10 px-4 text-sm',
+    sm: 'h-8 px-3 text-xs',
+    md: 'h-10 px-4 text-sm',
+    lg: 'h-12 px-6 text-base',
+  },
+  variant: {
+    primary: 'bg-white/15 backdrop-blur-md text-white border border-white/20 hover:bg-white/25 shadow-md',
+    secondary: 'bg-white/10 backdrop-blur-md text-white/70 border border-white/20 hover:bg-white/20',
+    outline: 'bg-transparent text-white border border-white/20 hover:bg-white/10',
+    ghost: 'bg-transparent text-white/70 hover:bg-white/10',
+    destructive: 'bg-red-500/10 text-red-300 border border-red-400/30 hover:bg-red-500/20',
+  },
+};
+
+/** Input System */
+export const input = {
+  base: `flex w-full rounded-lg text-sm text-white placeholder:text-white/60
+         bg-white/10 backdrop-blur-md border border-white/20
+         focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400/50
+         focus-visible:ring-offset-2 focus-visible:ring-offset-transparent
+         disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed
+         hover:bg-white/20 hover:border-white/30 transition-all duration-200 ease-out`,
+  size: {
+    default: 'h-10 px-4 text-sm',
+    sm: 'h-8 px-3 text-xs',
+    md: 'h-10 px-4 text-sm',
+    lg: 'h-12 px-4 text-base',
+  },
+};
+
+/** Card System */
+export const card = {
+  base: `backdrop-blur-md border border-white/20 transition-all duration-200 ease-out rounded-xl`,
+  variant: {
+    default: 'bg-white/10 shadow-sm',
+    elevated: 'bg-white/15 shadow-md border-white/25',
+    interactive: 'bg-white/15 shadow-md hover:bg-white/25 hover:shadow-xl hover:shadow-white/10 cursor-pointer hover:scale-[1.01]',
+    featured: 'bg-white/15 ring-1 ring-white/30 shadow-lg shadow-white/5',
+    compact: 'bg-white/10 shadow-sm',
+  },
+  padding: {
+    sm: 'p-3',
+    md: 'p-4',
+    lg: 'p-6',
+  },
+};
+
+/** Bento Grid System */
+export const bento = {
+  container: {
+    base: 'grid auto-rows-min grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-6',
+    gap: {
+      tight: 'gap-3',
+      default: 'gap-4',
+      loose: 'gap-6',
+    },
+  },
+  card: {
+    size: {
+      compact: 'min-h-[160px]',
+      default: 'min-h-[200px]',
+      medium: 'min-h-[240px]',
+      large: 'min-h-[280px]',
+      hero: 'min-h-[320px]',
+      tall: 'min-h-[380px]',
+    },
+    span: {
+      small: 'col-span-1 sm:col-span-2',
+      medium: 'col-span-2 lg:col-span-3',
+      large: 'col-span-2 md:col-span-3 lg:col-span-4',
+      hero: 'col-span-2 md:col-span-3 lg:col-span-4',
+      wide: 'col-span-full lg:col-span-6',
+      tall: 'col-span-2 lg:col-span-3',
+    },
+  },
+};

--- a/src/lib/styles/theme.ts
+++ b/src/lib/styles/theme.ts
@@ -1,0 +1,240 @@
+import React, { createContext, useContext, useState, useEffect } from "react";
+
+// ────────────────────────────────────────────────────────────────────────────────
+// THEME SYSTEM
+// ────────────────────────────────────────────────────────────────────────────────
+
+/** Theme Configuration Interface */
+export interface ThemeConfig {
+  name: string;
+  description: string;
+  colors: {
+    primary: string;
+    secondary: string;
+    accent: string;
+    background: string;
+    surface: string;
+    text: string;
+    textSecondary: string;
+    border: string;
+    glass: {
+      background: string;
+      border: string;
+      shadow: string;
+      backdrop: string;
+    };
+    gradient: {
+      primary: string;
+      secondary: string;
+      accent: string;
+    };
+    status: {
+      success: string;
+      warning: string;
+      error: string;
+      info: string;
+    };
+  };
+  effects: {
+    blur: string;
+    shadow: string;
+    border: string;
+    glow: string;
+  };
+}
+
+/** Predefined Theme Configurations */
+export const themes: Record<string, ThemeConfig> = {
+  medical: {
+    name: "Medical Blue",
+    description: "Professional medical theme with clinical blue tones",
+    colors: {
+      primary: "#0ea5e9",
+      secondary: "#0284c7",
+      accent: "#3b82f6",
+      background: "linear-gradient(135deg, #0c4a6e 0%, #0369a1 50%, #0284c7 100%)",
+      surface: "#f8fafc",
+      text: "#ffffff",
+      textSecondary: "rgba(255, 255, 255, 0.8)",
+      border: "rgba(255, 255, 255, 0.2)",
+      glass: {
+        background: "rgba(255, 255, 255, 0.1)",
+        border: "rgba(255, 255, 255, 0.2)",
+        shadow: "0 8px 32px rgba(0, 0, 0, 0.1)",
+        backdrop: "blur(20px)",
+      },
+      gradient: {
+        primary: "linear-gradient(135deg, #0ea5e9 0%, #3b82f6 100%)",
+        secondary: "linear-gradient(135deg, #0284c7 0%, #0c4a6e 100%)",
+        accent: "linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%)",
+      },
+      status: {
+        success: "#10b981",
+        warning: "#f59e0b",
+        error: "#ef4444",
+        info: "#3b82f6",
+      },
+    },
+    effects: {
+      blur: "blur(20px)",
+      shadow: "0 8px 32px rgba(0, 0, 0, 0.1)",
+      border: "1px solid rgba(255, 255, 255, 0.2)",
+      glow: "0 0 20px rgba(59, 130, 246, 0.3)",
+    },
+  },
+  emerald: {
+    name: "Emerald Medical",
+    description: "Fresh and modern medical theme with emerald accents",
+    colors: {
+      primary: "#10b981",
+      secondary: "#059669",
+      accent: "#34d399",
+      background: "linear-gradient(135deg, #064e3b 0%, #065f46 50%, #047857 100%)",
+      surface: "#f0fdf4",
+      text: "#ffffff",
+      textSecondary: "rgba(255, 255, 255, 0.8)",
+      border: "rgba(255, 255, 255, 0.2)",
+      glass: {
+        background: "rgba(255, 255, 255, 0.1)",
+        border: "rgba(255, 255, 255, 0.2)",
+        shadow: "0 8px 32px rgba(0, 0, 0, 0.1)",
+        backdrop: "blur(20px)",
+      },
+      gradient: {
+        primary: "linear-gradient(135deg, #10b981 0%, #34d399 100%)",
+        secondary: "linear-gradient(135deg, #059669 0%, #047857 100%)",
+        accent: "linear-gradient(135deg, #34d399 0%, #6ee7b7 100%)",
+      },
+      status: {
+        success: "#10b981",
+        warning: "#f59e0b",
+        error: "#ef4444",
+        info: "#3b82f6",
+      },
+    },
+    effects: {
+      blur: "blur(20px)",
+      shadow: "0 8px 32px rgba(0, 0, 0, 0.1)",
+      border: "1px solid rgba(255, 255, 255, 0.2)",
+      glow: "0 0 20px rgba(16, 185, 129, 0.3)",
+    },
+  },
+  purple: {
+    name: "Purple Medical",
+    description: "Sophisticated medical theme with purple and violet tones",
+    colors: {
+      primary: "#8b5cf6",
+      secondary: "#7c3aed",
+      accent: "#a78bfa",
+      background: "linear-gradient(135deg, #4c1d95 0%, #5b21b6 50%, #6d28d9 100%)",
+      surface: "#faf5ff",
+      text: "#ffffff",
+      textSecondary: "rgba(255, 255, 255, 0.8)",
+      border: "rgba(255, 255, 255, 0.2)",
+      glass: {
+        background: "rgba(255, 255, 255, 0.1)",
+        border: "rgba(255, 255, 255, 0.2)",
+        shadow: "0 8px 32px rgba(0, 0, 0, 0.1)",
+        backdrop: "blur(20px)",
+      },
+      gradient: {
+        primary: "linear-gradient(135deg, #8b5cf6 0%, #a78bfa 100%)",
+        secondary: "linear-gradient(135deg, #7c3aed 0%, #6d28d9 100%)",
+        accent: "linear-gradient(135deg, #a78bfa 0%, #c4b5fd 100%)",
+      },
+      status: {
+        success: "#10b981",
+        warning: "#f59e0b",
+        error: "#ef4444",
+        info: "#3b82f6",
+      },
+    },
+    effects: {
+      blur: "blur(20px)",
+      shadow: "0 8px 32px rgba(0, 0, 0, 0.1)",
+      border: "1px solid rgba(255, 255, 255, 0.2)",
+      glow: "0 0 20px rgba(139, 92, 246, 0.3)",
+    },
+  },
+};
+
+// ────────────────────────────────────────────────────────────────────────────────
+// THEME PROVIDER & CONTEXT
+// ────────────────────────────────────────────────────────────────────────────────
+
+interface ThemeContextType {
+  currentTheme: ThemeConfig;
+  setTheme: (themeName: string) => void;
+  availableThemes: string[];
+  getThemeNames: () => Array<{ name: string; description: string }>;
+}
+
+const ThemeContext = React.createContext<ThemeContextType | undefined>(undefined);
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [currentThemeName, setCurrentThemeName] = useState<string>("medical");
+  const currentTheme = themes[currentThemeName] || themes.medical;
+
+  const setTheme = (themeName: string) => {
+    if (themes[themeName]) {
+      setCurrentThemeName(themeName);
+      localStorage.setItem("selected-theme", themeName);
+    }
+  };
+
+  const availableThemes = Object.keys(themes);
+  const getThemeNames = () => Object.values(themes).map(theme => ({ name: theme.name, description: theme.description }));
+
+  // Load saved theme on mount
+  useEffect(() => {
+    const savedTheme = localStorage.getItem("selected-theme");
+    if (savedTheme && themes[savedTheme]) {
+      setCurrentThemeName(savedTheme);
+    }
+  }, []);
+
+  // Apply theme to document
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.add('dark');
+
+    // Apply CSS custom properties
+    Object.entries({
+      "--theme-primary": currentTheme.colors.primary,
+      "--theme-secondary": currentTheme.colors.secondary,
+      "--theme-accent": currentTheme.colors.accent,
+      "--theme-background": currentTheme.colors.background,
+      "--theme-surface": currentTheme.colors.surface,
+      "--theme-text": currentTheme.colors.text,
+      "--theme-text-secondary": currentTheme.colors.textSecondary,
+      "--theme-border": currentTheme.colors.border,
+      "--theme-glass-bg": currentTheme.colors.glass.background,
+      "--theme-glass-border": currentTheme.colors.glass.border,
+      "--theme-glass-shadow": currentTheme.colors.glass.shadow,
+      "--theme-glass-backdrop": currentTheme.colors.glass.backdrop,
+      "--theme-blur": currentTheme.effects.blur,
+      "--theme-shadow": currentTheme.effects.shadow,
+      "--theme-border-width": currentTheme.effects.border,
+      "--theme-glow": currentTheme.effects.glow,
+    }).forEach(([property, value]) => {
+      root.style.setProperty(property, value);
+    });
+
+    document.body.style.background = currentTheme.colors.background;
+    return () => root.classList.remove('dark');
+  }, [currentTheme]);
+
+  return React.createElement(
+    ThemeContext.Provider,
+    { value: { currentTheme, setTheme, availableThemes, getThemeNames } },
+    children
+  );
+};
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return context;
+};

--- a/src/lib/styles/utils.ts
+++ b/src/lib/styles/utils.ts
@@ -1,0 +1,92 @@
+import { ThemeConfig } from "./theme";
+import { animations } from "./animations";
+import { button, input, card, bento } from "./components";
+
+// ────────────────────────────────────────────────────────────────────────────────
+// UTILITY FUNCTIONS
+// ────────────────────────────────────────────────────────────────────────────────
+
+/** Get glassmorphic styles */
+export const getGlassmorphicStyles = (theme: ThemeConfig, variant: "default" | "elevated" | "subtle" | "light" = "default") => {
+  const baseStyles = {
+    backgroundColor: theme.colors.glass.background,
+    backdropFilter: theme.colors.glass.backdrop,
+    border: theme.colors.glass.border,
+    boxShadow: theme.colors.glass.shadow,
+  };
+
+  switch (variant) {
+    case "elevated":
+      return {
+        ...baseStyles,
+        backgroundColor: theme.colors.glass.background.replace("0.1", "0.15"),
+        boxShadow: "0 12px 40px rgba(0, 0, 0, 0.15)",
+        border: theme.colors.glass.border.replace("0.2", "0.3"),
+      };
+    case "subtle":
+      return {
+        ...baseStyles,
+        backgroundColor: theme.colors.glass.background.replace("0.1", "0.05"),
+        boxShadow: "0 4px 16px rgba(0, 0, 0, 0.05)",
+        border: theme.colors.glass.border.replace("0.2", "0.1"),
+      };
+    case "light":
+        return {
+          ...baseStyles,
+          backgroundColor: theme.colors.glass.background.replace("0.1", "0.12"),
+          boxShadow: "0 6px 20px rgba(0, 0, 0, 0.08)",
+          border: theme.colors.glass.border.replace("0.2", "0.25"),
+        };
+    default:
+      return baseStyles;
+  }
+};
+
+/** Get component styles */
+export const getComponentStyles = (component: 'button' | 'input' | 'card', variant?: string, size?: string) => {
+  const componentMap = { button, input, card };
+  const comp = componentMap[component];
+  if (!comp) return '';
+
+  let styles = comp.base;
+  if (variant && 'variant' in comp && comp.variant) {
+    const variantStyle = comp.variant[variant as keyof typeof comp.variant];
+    if (variantStyle) styles += ` ${variantStyle}`;
+  }
+  if (size && 'size' in comp && comp.size) {
+    const sizeStyle = comp.size[size as keyof typeof comp.size];
+    if (sizeStyle) styles += ` ${sizeStyle}`;
+  }
+
+  return styles.trim();
+};
+
+/** Get bento grid styles */
+export const getBentoStyles = (type: 'container' | 'card', variant?: string, size?: string) => {
+  if (type === 'container') {
+    const gap = variant || 'default';
+    return `${bento.container.base} ${bento.container.gap[gap as keyof typeof bento.container.gap]}`;
+  }
+
+  if (type === 'card') {
+    const cardSize = size || 'default';
+    const cardSpan = variant || 'medium';
+    return `${bento.card.size[cardSize as keyof typeof bento.card.size]} ${bento.card.span[cardSpan as keyof typeof bento.card.span]}`;
+  }
+
+  return '';
+};
+
+/** Check for reduced motion preference */
+export const prefersReducedMotion = () => {
+  if (typeof window === "undefined") return false;
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+};
+
+/** Get appropriate animation variants */
+export const getAnimationVariants = (animationName: keyof typeof animations) => {
+  if (prefersReducedMotion()) {
+    return { initial: { opacity: 0 }, visible: { opacity: 1 }, exit: { opacity: 0 } };
+  }
+  return animations[animationName];
+};

--- a/src/lib/ui-styles.ts
+++ b/src/lib/ui-styles.ts
@@ -1,6 +1,6 @@
 
 import { typography } from "./typography";
-import { buttonVariants as dsButtonVariants } from "./design-system";
+import { buttonVariants as dsButtonVariants } from "./styles/common";
 import { colors, spacing as dsSpacing } from "./design-tokens";
 
 const medicalSection = {
@@ -46,23 +46,7 @@ const commonStyles = {
 const iconWithText = "flex items-center gap-2";
 const inputBase = "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50";
 
-/** Enhanced focus ring for interactive elements */
-export const focusRing = "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400/50 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent";
-
-/** Disabled state styling */
-export const disabledState = "disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed";
-
-/** Enhanced glassmorphic effect */
-export const glassmorphic = `backdrop-blur-md border-white/20 transition-all duration-200 ease-out`;
-
-/** Enhanced glassmorphic backgrounds with better depth */
-export const glass = {
-  subtle: `${glassmorphic} bg-white/10 shadow-sm`,
-  elevated: `${glassmorphic} bg-white/15 shadow-md border-white/25`,
-  overlay: `backdrop-blur-xl border-white/25 bg-white/10 shadow-lg`,
-  card: `${glassmorphic} bg-white/10 rounded-xl shadow-sm border`,
-  cardElevated: `${glassmorphic} bg-white/15 rounded-xl shadow-md border`
-} as const;
+// focusRing, disabledState, glassmorphic, glass REMOVED as they are available in src/lib/styles/common.ts
 
 export const buttonVariants = {
   ...dsButtonVariants,

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -21,7 +21,7 @@ import {
 } from "@/components/ui/alert";
 import { CheckCircle2 } from "lucide-react";
 import UnifiedBackground from "@/components/backgrounds/UnifiedBackground";
-import { useTheme } from "@/lib/design-system";
+import { useTheme } from "@/lib/styles/theme";
 import {
   pageTransitionVariants as globalPageTransitionVariants, // Renamed to avoid conflict
   reducedMotionPageTransitionVariants as globalReducedMotionPageVariants, // Renamed

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -10,13 +10,10 @@ import { motion, AnimatePresence } from "framer-motion";
 import { MetricCardSkeleton } from "@/components/ui/dashboard-skeleton";
 import { DynamicRecentActivity } from "@/features/dashboard/components/DynamicRecentActivity";
 import { RecentCasesCarousel } from "@/components/ui/recent-cases-carousel";
-import { 
-  animations, 
-  getComponentStyles, 
-  card, 
-  button, 
-  useTheme 
-} from "@/lib/design-system";
+import { animations } from "@/lib/styles/animations";
+import { getComponentStyles } from "@/lib/styles/utils";
+import { card, button } from "@/lib/styles/components";
+import { useTheme } from "@/lib/styles/theme";
 import { typo, responsiveType } from "@/lib/typography";
 import { cn } from "@/lib/utils";
 


### PR DESCRIPTION
This commit breaks down the monolithic `design-system.ts` into multiple, more focused modules under `src/lib/styles/`:
- `common.ts`: For common utility styles like focus rings, disabled states, and glassmorphism.
- `theme.ts`: For theme configurations, ThemeProvider, and useTheme hook.
- `components.ts`: For component-specific style objects (button, input, card, bento).
- `animations.ts`: For animation variants and transitions.
- `utils.ts`: For utility functions related to the design system.

The original `design-system.ts` now acts as an aggregator, re-exporting from these new modules to maintain backward compatibility for most imports and the default export.

Key changes include:
- Creation of the new style modules.
- Migration of relevant code from `design-system.ts` to these modules.
- Update of `design-system.ts` to re-export from the new modules.
- Update of import statements across the codebase to point to the new, more specific modules where appropriate.
- Consolidation of redundant style definitions, particularly by refactoring UI components in `src/components/ui/` (like card, input, bento) to use styles from `src/lib/styles/components.ts`.
- Cleanup of `src/lib/ui-styles.ts` by removing definitions now duplicated in `src/lib/styles/common.ts`.

Automated tests timed out during execution, so I recommend thorough manual testing to ensure no regressions were introduced.